### PR TITLE
Fix analysis part with SingleJet triggers

### DIFF
--- a/AnalysisMacros/include/parameters.h
+++ b/AnalysisMacros/include/parameters.h
@@ -29,8 +29,8 @@ const int triggerValDi[n_triggerDi] = {40, 60, 80, 140, 200, 260, 320, 400, 500}
 const int triggerValDi_HF[n_triggerDi_HF]  = {60,80,100,160,220,300};
 const int triggerValSi_HF[n_triggerSi_HF]  = {60,80,140,200,260,320,400,450,500};
 
-// const int n_pt = 12;
-const int n_pt = 13;
+const int n_pt = 12;
+//const int n_pt = 13;
 const int n_pt_Si = 13;
 
 // // //for Si derived trigger
@@ -103,6 +103,7 @@ const TString pt_range_HF[n_pt]={
 /*
    siTrg comparisson
 RunB      RunC  RunD  highest
+40       40     40    40
 62       65     53    65
 70       71     74    74
 100      100    94    100
@@ -113,7 +114,6 @@ RunB      RunC  RunD  highest
 445      440    443   445
 566      560    564   566
 604      608    598   608
-*/
 
 const double pt_bins[n_pt] = {
 40 ,
@@ -140,6 +140,46 @@ const TString pt_range[n_pt]={
   "445",
   "566",
   "608","1000","2000"};
+
+  siTrg comparisson (2nd attempt)
+RunB      RunC  RunD  highest
+28        33      39    39
+72        72      72    72
+77        77      95    95
+160       159     159  160
+226       226     226  226
+283       283     281  283
+344       343     343  344
+443       441     442  443
+577       563     567  577
+606       603     599  606
+
+*/
+
+const double pt_bins[n_pt] = {
+39 ,
+72  ,
+95 ,
+160 ,
+226 ,
+283 ,
+344 ,
+443 ,
+577 ,
+606 ,1000,2000};
+
+const TString pt_range[n_pt]={
+  "39",
+  "72",
+  "95",
+  "160",
+  "226",
+  "283",
+  "344",
+  "443",
+  "577",
+  "606","1000","2000"};
+
 
 /* // [END]SingleJet triggers? ------------- */
 

--- a/AnalysisMacros/src/AdditionalAsymmetryPlots.cc
+++ b/AnalysisMacros/src/AdditionalAsymmetryPlots.cc
@@ -44,6 +44,7 @@ void CorrectionObject::AdditionalAsymmetryPlots(bool eta_abs, bool si_trg){
   TH1D *hdata_jet1_pt[(eta_abs ? n_eta : n_eta_full)-1];
   TH1D *hdata_jet2_pt[(eta_abs ? n_eta : n_eta_full)-1];  
   TH1D *hdata_jet3_pt[(eta_abs ? n_eta : n_eta_full)-1];
+  TH1D *hdata_jet3_eta[(eta_abs ? n_eta : n_eta_full)-1];
   
   int count = 0;
   TString name1 = "hist_data_A_";
@@ -56,6 +57,7 @@ void CorrectionObject::AdditionalAsymmetryPlots(bool eta_abs, bool si_trg){
       hdata_jet1_pt[j] = new TH1D(name2+"jet1_pt_"+eta_name,"",nResponseBins,0,600);
       hdata_jet2_pt[j] = new TH1D(name2+"jet2_pt_"+eta_name,"",nResponseBins,0,600);    
       hdata_jet3_pt[j] = new TH1D(name2+"jet3_pt_"+eta_name,"",nResponseBins,0,600);
+      hdata_jet3_eta[j] = new TH1D(name2+"jet3_eta_"+eta_name,"",100,-5.2,5.2);
       
     for(int k=0; k<n_pt-1; k++){
       TString pt_name = "pt_"+pt_range[k]+"_"+pt_range[k+1];
@@ -91,6 +93,7 @@ void CorrectionObject::AdditionalAsymmetryPlots(bool eta_abs, bool si_trg){
   TTreeReaderValue<Float_t> jet1_pt_data(myReader_DATA, "jet1_pt");
   TTreeReaderValue<Float_t> jet2_pt_data(myReader_DATA, "jet2_pt");
   TTreeReaderValue<Float_t> jet3_pt_data(myReader_DATA, "jet3_pt");
+  TTreeReaderValue<Float_t> jet3_eta_data(myReader_DATA, "jet3_eta");
     
   int myCount = 0;
   int myCount_cut = 0;
@@ -105,9 +108,10 @@ void CorrectionObject::AdditionalAsymmetryPlots(bool eta_abs, bool si_trg){
       for(int j=0; j<(eta_abs ? n_eta : n_eta_full)-1; j++){
 	if( (eta_abs ? fabs(*probejet_eta_data) : *probejet_eta_data) > (eta_abs ? eta_bins : eta_bins_full)[j+1] || (eta_abs ? fabs(*probejet_eta_data) : *probejet_eta_data)  < (eta_abs ? eta_bins : eta_bins_full)[j]) continue;
 	else{
-	  hdata_jet1_pt[j]->Fill(fabs(*jet1_pt_data),*weight_data);
-	  hdata_jet2_pt[j]->Fill(fabs(*jet2_pt_data),*weight_data);
-	  hdata_jet3_pt[j]->Fill(fabs(*jet3_pt_data),*weight_data);	  
+	  hdata_jet1_pt[j]->Fill(*jet1_pt_data,*weight_data);
+	  hdata_jet2_pt[j]->Fill(*jet2_pt_data,*weight_data);
+	  hdata_jet3_pt[j]->Fill(*jet3_pt_data,*weight_data);	  
+	  hdata_jet3_eta[j]->Fill(*jet3_eta_data,*weight_data);	  
 	  hdata_asymmetry[k][j]->Fill(*asymmetry_data,*weight_data);
 	  hdata_bsymmetry[k][j]->Fill(*bsymmetry_data,*weight_data);
 	  hdata_asymmetry_rho[k][j]->Fill(*asymmetry_data,*rho_data,*weight_data);
@@ -155,6 +159,7 @@ void CorrectionObject::AdditionalAsymmetryPlots(bool eta_abs, bool si_trg){
       hdata_jet1_pt[j]->Write();
       hdata_jet2_pt[j]->Write();
       hdata_jet3_pt[j]->Write();     
+      hdata_jet3_eta[j]->Write();     
   }
   test_out_data_jet_pt->Close();
   delete test_out_data_jet_pt;
@@ -309,7 +314,36 @@ void CorrectionObject::AdditionalAsymmetryPlots(bool eta_abs, bool si_trg){
       delete htemp_rel_data;
     
   }  
-  
+
+
+  for(int i=0; i<(eta_abs ? n_eta : n_eta_full)-1; i++){
+    TString eta_name = "eta_"+(eta_abs ? eta_range2 : eta_range2_full)[i]+"_"+(eta_abs ? eta_range2 : eta_range2_full)[i+1];
+    
+    TLatex *tex = new TLatex();
+    tex->SetNDC();
+    tex->SetTextSize(0.045); 
+    TString text = eta_range[i] + " < |#eta| < " + eta_range[i+1];
+
+    TLatex *tex_lumi = new TLatex();
+    tex_lumi->SetNDC();
+    tex_lumi->SetTextSize(0.045); 
+    
+      TCanvas* cFull_eta3 = new TCanvas();
+      tdrCanvas(cFull_eta3,"cFull_eta3",h,4,10,kSquare,CorrectionObject::_lumitag);
+      TH1D* htemp_rel_data;
+      TString name_rel_data = "hist_data_jet3_eta_"+eta_name;
+      htemp_rel_data = (TH1D*)f_jet_pt->Get(name_rel_data);
+      htemp_rel_data->Draw();
+      htemp_rel_data->GetXaxis()->SetTitle("eta jet3");
+      htemp_rel_data->GetYaxis()->SetTitle("Entries per Bin");      
+      // htemp_rel_data->GetXaxis()->SetLimits(-1.2,1.2);
+      htemp_rel_data->Draw("EP");		
+      tex->DrawLatex(0.47,0.85,"Data, " + text);
+      cFull_eta3->SaveAs(CorrectionObject::_outpath+"plots/control/fullAsym/jet3_eta_DATA_" + CorrectionObject::_generator_tag + "_eta_" + (eta_abs ? eta_range2 : eta_range2_full)[i] + "_" + (eta_abs ? eta_range2 : eta_range2_full)[i+1]+ ".pdf");
+      delete cFull_eta3;
+      delete htemp_rel_data;
+    
+  }  
 
    TFile* f_rel_data_nvert = new TFile(CorrectionObject::_outpath+"plots/control/A_nvert_2d_data.root","READ");
   for(int i=0; i<(eta_abs ? n_eta : n_eta_full)-1; i++){

--- a/AnalysisMacros/src/Derive_Thresholds_SiJet.cc
+++ b/AnalysisMacros/src/Derive_Thresholds_SiJet.cc
@@ -360,7 +360,8 @@ void CorrectionObject::Derive_Thresholds_SiJet(bool pt_check, bool useHF){
   TF1* func095 = new TF1("func095", "pol1" , 0, 501);
   func095->SetLineColor(kBlue);
   TFitResultPtr r = gr095->Fit(func095);
-  all_thresholds[0]=gr095->Eval(40);
+  //  all_thresholds[0]=gr095->Eval(40);
+  all_thresholds[0]=func095->Eval(40);
   for(int i=0; i<n_trigger-1; i++){
     if(use_for_extrapol[i]) all_thresholds[i+1]=thresholds[i];
     else all_thresholds[i+1]=gr095->Eval(triggerVal_noLow[i]);
@@ -370,7 +371,8 @@ void CorrectionObject::Derive_Thresholds_SiJet(bool pt_check, bool useHF){
   TGraphErrors* gr09 = new TGraphErrors(n_extrapol, extrapol_x09 , extrapol_y09);
   TF1* func09 = new TF1("func09", "pol1" , 0, 501);
   r = gr09->Fit(func09);  
-  all_thresholds09[0]=gr09->Eval(40);
+  //  all_thresholds09[0]=gr09->Eval(40);
+  all_thresholds09[0]=func09->Eval(40);
   for(int i=0; i<n_trigger-1; i++){
     if(use_for_extrapol[i]) all_thresholds09[i+1]=thresholds09[i];
     else all_thresholds09[i+1]=gr09->Eval(triggerVal_noLow[i]);
@@ -403,7 +405,7 @@ void CorrectionObject::Derive_Thresholds_SiJet(bool pt_check, bool useHF){
   gr095->Draw("ap");
   c->Print(CorrectionObject::_outpath+"plots/thresholds/"+"extrapolateLowestTrigger095"+".pdf","pdf");    
    TCanvas* c2 = new TCanvas("c2");
-   gr09->SetMarkerStyle(3);
+   gr09->SetMarkerStyle(20);
    gr095->SetMarkerStyle(5);
   TMultiGraph* mg = new TMultiGraph();
   mg->Add(gr09);

--- a/AnalysisMacros/src/JetEnergyFractions.cc
+++ b/AnalysisMacros/src/JetEnergyFractions.cc
@@ -818,8 +818,8 @@ void CorrectionObject::JetEnergyFractions(double abs_asymmetry_cut, bool create_
       // h->SetMaximum(0.3);
       //      hEF->GetXaxis()->SetLimits(0,1.1);
       hEF->GetXaxis()->SetLimits(-3.15,3.15);
-      //      hEF->GetYaxis()->SetLimits(0,0.1);
-      hEF->SetMaximum(3);
+      hEF->GetYaxis()->SetLimits(0,0.1);
+      //      hEF->SetMaximum(3);
       //      hEF->SetMaximum(0.8);
       if(j<9) htemp_probejet_phi_mc->SetLineColor(j+1);
       else    htemp_probejet_phi_mc->SetLineColor(j+31);
@@ -852,8 +852,8 @@ void CorrectionObject::JetEnergyFractions(double abs_asymmetry_cut, bool create_
       // h->SetMaximum(0.3);
       // hEF->GetXaxis()->SetLimits(0,1.1);
       hEF->GetXaxis()->SetLimits(-3.15,3.15);
-      //      hEF->GetYaxis()->SetLimits(0,0.1);
-      hEF->SetMaximum(3);
+      hEF->GetYaxis()->SetLimits(0,0.1);
+      //      hEF->SetMaximum(3);
       //hEF->SetMaximum(0.8);
       if(j<9) htemp_probejet_phi_data->SetLineColor(j+1);
       else    htemp_probejet_phi_data->SetLineColor(j+31);

--- a/AnalysisMacros/src/Pt_Extrapolation_Alternative_CorrectFormulae.cc
+++ b/AnalysisMacros/src/Pt_Extrapolation_Alternative_CorrectFormulae.cc
@@ -183,7 +183,7 @@ void CorrectionObject::Pt_Extrapolation_Alternative_CorrectFormulae(bool mpfMeth
   for(int j=0; j<n_eta-1; j++){
     for(int k=0; k<n_pt-1; k++){
       enough_entries[j][k] = false;
-      if(n_entries_mc[j][k] > 250 && n_entries_data[j][k] > 250) enough_entries[j][k] = true;
+      if(n_entries_mc[j][k] > 50 && n_entries_data[j][k] > 50) enough_entries[j][k] = true;
     }
   }
 

--- a/AnalysisMacros/src/kFSR_CorrectFormulae.cc
+++ b/AnalysisMacros/src/kFSR_CorrectFormulae.cc
@@ -154,7 +154,7 @@ void CorrectionObject::kFSR_CorrectFormulae(){
      for(int j=0; j<n_eta-1; j++){
        for(int k=0; k<n_pt-1; k++){
 	 enough_entries[i][j][k] = false;
-	 if(n_entries_mc[j][i][k] > 250 && n_entries_data[j][i][k] > 250) enough_entries[i][j][k] = true;
+	 if(n_entries_mc[j][i][k] > 50 && n_entries_data[j][i][k] > 50) enough_entries[i][j][k] = true;
 	}
      }
    }

--- a/AnalysisMacros/src/main.C
+++ b/AnalysisMacros/src/main.C
@@ -373,7 +373,10 @@ int main(int argc,char *argv[]){
     if(do_oor_plot) for(unsigned int i=0; i<Objects.size(); i++) Objects[i].OnOffResp_Plots();
    if(do_matchtrg_plotdi) for(unsigned int i=0; i<Objects.size(); i++) Objects[i].JetMatching_PlotsDi();
     if(do_oor_plotdi) for(unsigned int i=0; i<Objects.size(); i++) Objects[i].OnOffResp_PlotsDi(useHF);
-    if(do_addAsymPlots) for(unsigned int i=0; i<Objects.size(); i++) Objects[i].AdditionalAsymmetryPlots();
+    if(do_addAsymPlots){
+      for(unsigned int i=0; i<Objects.size(); i++) Objects[i].AdditionalAsymmetryPlots();
+      //   for(unsigned int i=0; i<Objects.size(); i++) Objects[i].JetEnergyFractions();
+    }
     if(do_addAsymPlotsef) for(unsigned int i=0; i<Objects.size(); i++) Objects[i].AdditionalAsymmetryPlots(false);
     if(do_triggerEx) for(unsigned int i=0; i<Objects.size(); i++) Objects[i].triggerExclusivityCheck();
 

--- a/AnalysisMacros/src/useful_functions.cc
+++ b/AnalysisMacros/src/useful_functions.cc
@@ -24,7 +24,7 @@ pair<double,double> GetValueAndError(TH1D *hin){
   //  res.first = -1; res.second = -1;
   //  if(hin->GetEntries()>30){
   //  if(hin->GetEntries()>50){
-  if(hin->GetEntries()>250){  
+  if(hin->GetEntries()>50){  
     res.first = hin->GetMean();
     // GetMeanError calculates the uncertainty on the mean value, arising due to limited statistics in the sample. We dont care for the width itself, only the uncertainty on the predicted mean is relevant.
     res.second = hin->GetMeanError();

--- a/conf/BaconJets_AnalyseModule_DiJet_Anastasia_HF.xml
+++ b/conf/BaconJets_AnalyseModule_DiJet_Anastasia_HF.xml
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd"[
+
+
+<!ENTITY PROOFdir            "/nfs/dust/cms/user/garbersc/forBaconJets/.proof2"> 
+<!ENTITY NEVT                "-1">
+
+<!ENTITY CACHEABLE           "False">
+<!-- <!ENTITY OUTdir              "/nfs/dust/cms/user/garbersc/forBaconJets/17Nov2017/Residuals/Run17F_Data_woHOTVR_woXCON_JEC_V4_2/"> -->
+
+<!ENTITY OUTdir              "/nfs/dust/cms/user/karavdia/JERC/Fall17_17Nov_V4_L2Res_wMPF_CentralTriggers_And_HF/">
+
+<!ENTITY b_closuretest       "false">
+<!ENTITY jec_version         "Fall17_17Nov2017_V4">
+<!ENTITY APPLY_WEIGHTS       "false">
+<!ENTITY WEIGHT_PATH         "/nfs/dust/cms/user/multh/JEC/2016ReReco/Residuals/Summer16_03Feb2017_V3/AK4CHS/MC_Reweighted_chsMET_NewTriggerSetup_ForWeights/"> <!-- Change Weight-Path: CENTRAL/FWD -->
+<!ENTITY Cut_PATH            "/nfs/dust/cms/user/multh/JEC/2016ReReco/Residuals/Summer16_03Feb2017_V3/AK4CHS/EtaPhiCut/">
+
+<!ENTITY APPLY_METoverPTcut  "false">  <!--Apply MET Cut-->
+<!ENTITY APPLY_EtaPhi_cut    "false">   <!--Apply Eta Phi cleaning during ECAL problems -->
+<!ENTITY APPLY_LUMIWEIGHTS   "false"> 
+<!ENTITY APPLY_UNFLATTENING  "false">
+<!ENTITY TRIGGER_CENTRAL     "true">  <!--Trigger Flag -->
+<!ENTITY TRIGGER_FWD         "true"> <!--Trigger Flag -->
+
+<!ENTITY ONLY_BACK_TO_BACK "false" >
+<!ENTITY USE_SINGLE_TRIGGER "false" > <!-- if true use the single jet trigger, else the dijet trigger -->
+
+<!ENTITY QCDPt50to80_pythia8_AK4CHS           SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_50to80_EGReg_chsMET.xml">
+<!ENTITY QCDPt80to120_pythia8_AK4CHS          SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_80to120_EGReg_chsMET.xml">
+<!ENTITY QCDPt120to170_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_120to170_EGReg_chsMET.xml">
+<!ENTITY QCDPt170to300_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_170to300_EGReg_chsMET.xml">
+<!ENTITY QCDPt300to470_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_300to470_EGReg_chsMET.xml">
+<!ENTITY QCDPt470to600_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_470to600_EGReg_chsMET.xml">
+<!ENTITY QCDPt600to800_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt600to800_pythia8_AK4CHS_ext1    SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt800to1000_pythia8_AK4CHS        SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt800to1000_pythia8_AK4CHS_ext1   SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt1000to1400_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt1000to1400_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt1400to1800_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt1400to1800_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt1800to2400_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt1800to2400_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt2400to3200_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt2400to3200_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt3200toInf_pythia8_AK4CHS        SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_3200toInf_EGReg_chsMET.xml">
+
+
+<!--
+<!ENTITY DATA_RunB_promptReco_2017 SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17_clean160118/CMSSW_9_4_1/src/UHH2/common/datasets/RunII_94X_v1/">
+
+<!ENTITY DATA_RunC_promptReco_2017 SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17_clean160118/CMSSW_9_4_1/src/UHH2/common/datasets/RunII_94X_v1/JetHT_RunC_17Nov17_v1.xml">
+
+<!ENTITY DATA_RunE_promptReco_2017 SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17_clean300118/CMSSW_9_4_1/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunE_17Nov2017.xml">
+
+
+-->
+<!ENTITY DATA_RunF_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunF_17Nov2017_wCHSMETfixed.xml">
+
+<!ENTITY DATA_RunD_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunD_17Nov2017_wCHSMETfixed.xml">
+
+<!ENTITY QCDPt15to7000 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/MC_QCD_Flat2017_pythia8_wCHSMETfixed.xml">
+
+<!ENTITY DATA_RunE_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunE_17Nov17_v1.xml">
+
+]>
+
+
+<!--
+<ConfigParse NEventsBreak="0" FileSplit="10" AutoResubmit="5"/>
+<ConfigSGE RAM ="2" DISK ="3" Mail="xxx@desy.de" Notification="as" Workdir="/nfs/dust/cms/user/karavdia/JERC/workdir_Data_Run17_wCHSMETfix_HF_2"/>
+-->
+
+<!-- OutputLevel controls which messages are printed; set to VERBOSE or DEBUG for more verbosity, to WARNING or ERROR or INFO for less -->
+ <JobConfiguration JobName="ExampleCycleJob" OutputLevel="INFO"> 
+    <Library Name="libSUHH2BaconJets"/>
+    <Package Name="SUHH2BaconJets.par" />
+
+ <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&OUTdir;/" PostFix="" TargetLumi="8317" > 
+<!-- <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&OUTdir;/" PostFix="" TargetLumi="4553" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="15" > -->
+
+
+<!-- <InputData Lumi="0.518" NEventsMax="&NEVT;" Type="MC" Version="QCDPt50to80_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt50to80_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="5.283" NEventsMax="&NEVT;" Type="MC" Version="QCDPt80to120_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt80to120_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="26.443" NEventsMax="&NEVT;" Type="MC" Version="QCDPt120to170_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt120to170_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="125.998" NEventsMax="&NEVT;" Type="MC" Version="QCDPt170to300_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt170to300_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="2841.593" NEventsMax="&NEVT;" Type="MC" Version="QCDPt300to470_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt300to470_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="6100.393" NEventsMax="&NEVT;" Type="MC" Version="QCDPt470to600_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt470to600_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="72315.548" NEventsMax="&NEVT;" Type="MC" Version="QCDPt600to800_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt600to800_pythia8_AK4CHS; &QCDPt600to800_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="609694.175" NEventsMax="&NEVT;" Type="MC" Version="QCDPt800to1000_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt800to1000_pythia8_AK4CHS; &QCDPt800to1000_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="1059141.459" NEventsMax="&NEVT;" Type="MC" Version="QCDPt1000to1400_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt1000to1400_pythia8_AK4CHS; &QCDPt1000to1400_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="3394810.420" NEventsMax="&NEVT;" Type="MC" Version="QCDPt1400to1800_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt1400to1800_pythia8_AK4CHS; &QCDPt1400to1800_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="16852065.807" NEventsMax="&NEVT;" Type="MC" Version="QCDPt1800to2400_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt1800to2400_pythia8_AK4CHS; &QCDPt1800to2400_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="144125092.792" NEventsMax="&NEVT;" Type="MC" Version="QCDPt2400to3200_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt2400to3200_pythia8_AK4CHS; &QCDPt2400to3200_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="2362102209.193" NEventsMax="&NEVT;" Type="MC" Version="QCDPt3200toInf_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt3200toInf_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+
+
+<InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="QCDPt15to7000" Cacheable="&CACHEABLE;">
+          &QCDPt15to7000;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+     </InputData>
+<!-- <InputData Lumi="36311468" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunD_17Nov17_2017" Cacheable="&CACHEABLE;"> -->
+
+<InputData Lumi="1" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunD_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunD_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+
+
+<InputData Lumi="1" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunF_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunF_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+
+<InputData Lumi="1" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunE_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunE_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+
+    <UserConfig>
+      <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices"/>
+      <!-- <Item Name="GenParticleCollection"   Value="GenParticles"/> -->
+<!--      <Item Name="GenParticleCollection"   Value="slimmedJets"/> --> <!-- bullshit for MC with missing GenParticles -->
+      <Item Name="ElectronCollection"      Value="slimmedElectronsUSER"/> <!-- change depending on 2016 MC or 17 data!!! -->
+      <Item Name="MuonCollection"          Value="slimmedMuonsUSER"/>
+      <Item Name="TauCollection"           Value="slimmedTaus"/>
+      <!-- AK4CHS -->
+      <Item Name="JetCollection"           Value="slimmedJets"/>
+      <Item Name="JetLabel"                Value="AK4CHS"/> 
+      <Item Name="GenJetCollection"        Value="slimmedGenJets"/>    <!-- bullshit for MC with missing GenParticles -->
+      <!-- <Item Name="METName"                 Value="slMETsCHS"/> -->
+      <Item Name="METName"                 Value="slimmedMETs"/>
+      
+      <!-- <Item Name="lumi_file" Value="/nfs/dust/cms/user/garbersc/UHH2_17/CMSSW_9_2_7_patch1/src/UHH2/common/data/Cert_13TeV_2017_HCAL_DCS_GOOD_11Jul.root"/> -->
+
+       <Item Name="lumi_file" Value="/nfs/dust/cms/user/garbersc/UHH2_17_clean300118/CMSSW_9_4_1/src/UHH2/common/data/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.root"/>
+     
+      <!--
+      	 <Item Name="pileup_directory"           Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/>
+	 <Item Name="pileup_directory_data"      Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/>
+	 <Item Name="pileup_directory_data_up"   Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/>
+	 <Item Name="pileup_directory_data_down" Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/> 
+	 <Item Name="pileup_directory_data"      Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/800pb/nPU_minBiasXsec71300.root"/>
+	 <Item Name="pileup_directory_data_up"   Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/800pb/nPU_minBiasXsec80000.root"/>
+	 <Item Name="pileup_directory_data_down" Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/800pb/nPU_minBiasXsec58000.root"/> -->
+
+
+      <Item Name="lumihists_lumi_per_bin" Value="50."/>
+
+
+<!--      <Item Name="use_sframe_weight" Value="true"/> -->  <!--false-->
+      <Item Name="use_sframe_weight" Value="false"/>
+
+      <Item Name="trigger40" Value="HLT_DiPFJetAve40_v*"/>
+      <Item Name="trigger60" Value="HLT_DiPFJetAve60_v*"/>
+      <Item Name="trigger80" Value="HLT_DiPFJetAve80_v*"/>
+      <Item Name="trigger140" Value="HLT_DiPFJetAve140_v*"/>
+      <Item Name="trigger200" Value="HLT_DiPFJetAve200_v*"/>
+      <Item Name="trigger260" Value="HLT_DiPFJetAve260_v*"/>
+      <Item Name="trigger320" Value="HLT_DiPFJetAve320_v*"/>
+      <Item Name="trigger400" Value="HLT_DiPFJetAve400_v*"/>
+      <Item Name="trigger500" Value="HLT_DiPFJetAve500_v*"/>
+
+      <Item Name="trigger60_HFJEC" Value="HLT_DiPFJetAve60_HFJEC_v*"/>
+      <Item Name="trigger80_HFJEC" Value="HLT_DiPFJetAve80_HFJEC_v*"/>
+      <Item Name="trigger100_HFJEC" Value="HLT_DiPFJetAve100_HFJEC_v*"/>
+      <Item Name="trigger160_HFJEC" Value="HLT_DiPFJetAve160_HFJEC_v*"/>
+      <Item Name="trigger220_HFJEC" Value="HLT_DiPFJetAve220_HFJEC_v*"/>
+      <Item Name="trigger300_HFJEC" Value="HLT_DiPFJetAve300_HFJEC_v*"/>      
+
+	<!-- Closure test? -->
+	<Item Name="ClosureTest" Value="&b_closuretest;"/>
+	<!--<Item Name="Split_JEC_DATA" Value="&b_splitjec_data;"/>
+	<Item Name="Split_JEC_MC" Value="&b_splitjec_mc;"/>-->
+	<Item Name="JEC_Version" Value="&jec_version;"/>
+
+	<!-- Systematic uncertainties -->
+	<Item Name="jersmear_direction" Value="nominal"/> <!--nominal/down/up -->
+
+	<Item Name="Apply_Lumiweights"  Value="&APPLY_LUMIWEIGHTS;"/>
+	<Item Name="Apply_Unflattening" Value="&APPLY_UNFLATTENING;"/>
+	<Item Name="Apply_Weights" Value="&APPLY_WEIGHTS;"/>
+	<Item Name="MC_Weights_Path" Value="&WEIGHT_PATH;"/>
+	<Item Name="METoverPt_cut" Value="&APPLY_METoverPTcut;"/>
+	<Item Name="EtaPhi_cut" Value="&APPLY_EtaPhi_cut;"/>
+	<Item Name="Cut_dir"  Value="&Cut_PATH;"/>
+
+	<Item Name="Trigger_Central"    Value="&TRIGGER_CENTRAL;"/>
+	<Item Name="Trigger_FWD"        Value="&TRIGGER_FWD;"/>
+	
+	<Item Name="Trigger_Single"        Value="&USE_SINGLE_TRIGGER;"/>	
+	<Item Name="Only_BtB"               Value="&ONLY_BACK_TO_BACK;"/>
+	
+	<!-- always apply MET smearing -->
+
+            <!-- tell AnalysisModuleRunner that we use a completely user-defined event format -->
+       <!--     <Item Name="userEventFormat" Value="true" /> -->
+	  <!-- <Item Name="userEventFormat" Value="false" /> -->
+            <!-- the class name of the AnalysisModule subclasses to run: -->
+            <Item Name="AnalysisModule" Value="AnalysisModule_DiJetTrg" /> 
+	    <!--    <Item Name="MCreweight" Value="false" /> -->
+
+        <Item Name="Debug" Value="false" />	    
+
+        </UserConfig>
+    </Cycle>
+</JobConfiguration>

--- a/conf/BaconJets_AnalyseModule_DiJet_Anastasia_JERdown.xml
+++ b/conf/BaconJets_AnalyseModule_DiJet_Anastasia_JERdown.xml
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd"[
+
+
+<!ENTITY PROOFdir            "/nfs/dust/cms/user/garbersc/forBaconJets/.proof2"> 
+<!ENTITY NEVT                "-1">
+
+<!ENTITY CACHEABLE           "False">
+<!-- <!ENTITY OUTdir              "/nfs/dust/cms/user/garbersc/forBaconJets/17Nov2017/Residuals/Run17F_Data_woHOTVR_woXCON_JEC_V4_2/"> -->
+
+<!ENTITY OUTdir              "/nfs/dust/cms/user/karavdia/JERC/Fall17_17Nov_V4_L2Res_wMPF_CentralTriggersONLY_JERdown/">
+
+<!ENTITY b_closuretest       "false">
+<!ENTITY jec_version         "Fall17_17Nov2017_V4">
+<!ENTITY APPLY_WEIGHTS       "false">
+<!ENTITY WEIGHT_PATH         "/nfs/dust/cms/user/multh/JEC/2016ReReco/Residuals/Summer16_03Feb2017_V3/AK4CHS/MC_Reweighted_chsMET_NewTriggerSetup_ForWeights/"> <!-- Change Weight-Path: CENTRAL/FWD -->
+<!ENTITY Cut_PATH            "/nfs/dust/cms/user/multh/JEC/2016ReReco/Residuals/Summer16_03Feb2017_V3/AK4CHS/EtaPhiCut/">
+
+<!ENTITY APPLY_METoverPTcut  "false">  <!--Apply MET Cut-->
+<!ENTITY APPLY_EtaPhi_cut    "false">   <!--Apply Eta Phi cleaning during ECAL problems -->
+<!ENTITY APPLY_LUMIWEIGHTS   "false"> 
+<!ENTITY APPLY_UNFLATTENING  "false">
+<!ENTITY TRIGGER_CENTRAL     "true">  <!--Trigger Flag -->
+<!ENTITY TRIGGER_FWD         "false"> <!--Trigger Flag -->
+
+<!ENTITY ONLY_BACK_TO_BACK "false" >
+<!ENTITY USE_SINGLE_TRIGGER "false" > <!-- if true use the single jet trigger, else the dijet trigger -->
+
+<!ENTITY QCDPt50to80_pythia8_AK4CHS           SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_50to80_EGReg_chsMET.xml">
+<!ENTITY QCDPt80to120_pythia8_AK4CHS          SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_80to120_EGReg_chsMET.xml">
+<!ENTITY QCDPt120to170_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_120to170_EGReg_chsMET.xml">
+<!ENTITY QCDPt170to300_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_170to300_EGReg_chsMET.xml">
+<!ENTITY QCDPt300to470_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_300to470_EGReg_chsMET.xml">
+<!ENTITY QCDPt470to600_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_470to600_EGReg_chsMET.xml">
+<!ENTITY QCDPt600to800_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt600to800_pythia8_AK4CHS_ext1    SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt800to1000_pythia8_AK4CHS        SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt800to1000_pythia8_AK4CHS_ext1   SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt1000to1400_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt1000to1400_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt1400to1800_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt1400to1800_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt1800to2400_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt1800to2400_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt2400to3200_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt2400to3200_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt3200toInf_pythia8_AK4CHS        SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_3200toInf_EGReg_chsMET.xml">
+
+
+<!--
+<!ENTITY DATA_RunB_promptReco_2017 SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17_clean160118/CMSSW_9_4_1/src/UHH2/common/datasets/RunII_94X_v1/">
+
+<!ENTITY DATA_RunC_promptReco_2017 SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17_clean160118/CMSSW_9_4_1/src/UHH2/common/datasets/RunII_94X_v1/JetHT_RunC_17Nov17_v1.xml">
+
+<!ENTITY DATA_RunE_promptReco_2017 SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17_clean300118/CMSSW_9_4_1/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunE_17Nov2017.xml">
+
+
+-->
+<!ENTITY DATA_RunF_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunF_17Nov2017_wCHSMETfixed.xml">
+
+<!ENTITY DATA_RunD_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunD_17Nov2017_wCHSMETfixed.xml">
+
+<!ENTITY QCDPt15to7000 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/MC_QCD_Flat2017_pythia8_wCHSMETfixed.xml">
+
+<!ENTITY DATA_RunE_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunE_17Nov17_v1.xml">
+
+]>
+
+
+<!--
+<ConfigParse NEventsBreak="0" FileSplit="15" AutoResubmit="5"/>
+<ConfigSGE RAM ="2" DISK ="3" Mail="xxx@desy.de" Notification="as" Workdir="/nfs/dust/cms/user/karavdia/JERC/workdir_Data_Run17_wCHSMETfix_3_JERdown_2"/>
+-->
+
+<!-- OutputLevel controls which messages are printed; set to VERBOSE or DEBUG for more verbosity, to WARNING or ERROR or INFO for less -->
+ <JobConfiguration JobName="ExampleCycleJob" OutputLevel="INFO"> 
+    <Library Name="libSUHH2BaconJets"/>
+    <Package Name="SUHH2BaconJets.par" />
+
+ <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&OUTdir;/" PostFix="" TargetLumi="8317" > 
+<!-- <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&OUTdir;/" PostFix="" TargetLumi="4553" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="15" > -->
+
+
+<!-- <InputData Lumi="0.518" NEventsMax="&NEVT;" Type="MC" Version="QCDPt50to80_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt50to80_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="5.283" NEventsMax="&NEVT;" Type="MC" Version="QCDPt80to120_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt80to120_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="26.443" NEventsMax="&NEVT;" Type="MC" Version="QCDPt120to170_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt120to170_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="125.998" NEventsMax="&NEVT;" Type="MC" Version="QCDPt170to300_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt170to300_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="2841.593" NEventsMax="&NEVT;" Type="MC" Version="QCDPt300to470_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt300to470_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="6100.393" NEventsMax="&NEVT;" Type="MC" Version="QCDPt470to600_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt470to600_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="72315.548" NEventsMax="&NEVT;" Type="MC" Version="QCDPt600to800_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt600to800_pythia8_AK4CHS; &QCDPt600to800_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="609694.175" NEventsMax="&NEVT;" Type="MC" Version="QCDPt800to1000_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt800to1000_pythia8_AK4CHS; &QCDPt800to1000_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="1059141.459" NEventsMax="&NEVT;" Type="MC" Version="QCDPt1000to1400_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt1000to1400_pythia8_AK4CHS; &QCDPt1000to1400_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="3394810.420" NEventsMax="&NEVT;" Type="MC" Version="QCDPt1400to1800_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt1400to1800_pythia8_AK4CHS; &QCDPt1400to1800_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="16852065.807" NEventsMax="&NEVT;" Type="MC" Version="QCDPt1800to2400_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt1800to2400_pythia8_AK4CHS; &QCDPt1800to2400_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="144125092.792" NEventsMax="&NEVT;" Type="MC" Version="QCDPt2400to3200_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt2400to3200_pythia8_AK4CHS; &QCDPt2400to3200_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="2362102209.193" NEventsMax="&NEVT;" Type="MC" Version="QCDPt3200toInf_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt3200toInf_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+
+
+<InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="QCDPt15to7000" Cacheable="&CACHEABLE;">
+          &QCDPt15to7000;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+     </InputData>
+
+<!--
+<InputData Lumi="1" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunD_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunD_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+
+
+<InputData Lumi="1" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunF_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunF_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+
+<InputData Lumi="1" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunE_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunE_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+-->
+    <UserConfig>
+      <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices"/>
+      <!-- <Item Name="GenParticleCollection"   Value="GenParticles"/> -->
+<!--      <Item Name="GenParticleCollection"   Value="slimmedJets"/> --> <!-- bullshit for MC with missing GenParticles -->
+      <Item Name="ElectronCollection"      Value="slimmedElectronsUSER"/> <!-- change depending on 2016 MC or 17 data!!! -->
+      <Item Name="MuonCollection"          Value="slimmedMuonsUSER"/>
+      <Item Name="TauCollection"           Value="slimmedTaus"/>
+      <!-- AK4CHS -->
+      <Item Name="JetCollection"           Value="slimmedJets"/>
+      <Item Name="JetLabel"                Value="AK4CHS"/> 
+      <Item Name="GenJetCollection"        Value="slimmedGenJets"/>    <!-- bullshit for MC with missing GenParticles -->
+      <!-- <Item Name="METName"                 Value="slMETsCHS"/> -->
+      <Item Name="METName"                 Value="slimmedMETs"/>
+      
+      <!-- <Item Name="lumi_file" Value="/nfs/dust/cms/user/garbersc/UHH2_17/CMSSW_9_2_7_patch1/src/UHH2/common/data/Cert_13TeV_2017_HCAL_DCS_GOOD_11Jul.root"/> -->
+
+       <Item Name="lumi_file" Value="/nfs/dust/cms/user/garbersc/UHH2_17_clean300118/CMSSW_9_4_1/src/UHH2/common/data/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.root"/>
+     
+      <!--
+      	 <Item Name="pileup_directory"           Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/>
+	 <Item Name="pileup_directory_data"      Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/>
+	 <Item Name="pileup_directory_data_up"   Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/>
+	 <Item Name="pileup_directory_data_down" Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/> 
+	 <Item Name="pileup_directory_data"      Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/800pb/nPU_minBiasXsec71300.root"/>
+	 <Item Name="pileup_directory_data_up"   Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/800pb/nPU_minBiasXsec80000.root"/>
+	 <Item Name="pileup_directory_data_down" Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/800pb/nPU_minBiasXsec58000.root"/> -->
+
+
+      <Item Name="lumihists_lumi_per_bin" Value="50."/>
+
+
+<!--      <Item Name="use_sframe_weight" Value="true"/> -->  <!--false-->
+      <Item Name="use_sframe_weight" Value="false"/>
+
+      <Item Name="trigger40" Value="HLT_DiPFJetAve40_v*"/>
+      <Item Name="trigger60" Value="HLT_DiPFJetAve60_v*"/>
+      <Item Name="trigger80" Value="HLT_DiPFJetAve80_v*"/>
+      <Item Name="trigger140" Value="HLT_DiPFJetAve140_v*"/>
+      <Item Name="trigger200" Value="HLT_DiPFJetAve200_v*"/>
+      <Item Name="trigger260" Value="HLT_DiPFJetAve260_v*"/>
+      <Item Name="trigger320" Value="HLT_DiPFJetAve320_v*"/>
+      <Item Name="trigger400" Value="HLT_DiPFJetAve400_v*"/>
+      <Item Name="trigger500" Value="HLT_DiPFJetAve500_v*"/>
+
+      <Item Name="trigger60_HFJEC" Value="HLT_DiPFJetAve60_HFJEC_v*"/>
+      <Item Name="trigger80_HFJEC" Value="HLT_DiPFJetAve80_HFJEC_v*"/>
+      <Item Name="trigger100_HFJEC" Value="HLT_DiPFJetAve100_HFJEC_v*"/>
+      <Item Name="trigger160_HFJEC" Value="HLT_DiPFJetAve160_HFJEC_v*"/>
+      <Item Name="trigger220_HFJEC" Value="HLT_DiPFJetAve220_HFJEC_v*"/>
+      <Item Name="trigger300_HFJEC" Value="HLT_DiPFJetAve300_HFJEC_v*"/>      
+
+	<!-- Closure test? -->
+	<Item Name="ClosureTest" Value="&b_closuretest;"/>
+	<!--<Item Name="Split_JEC_DATA" Value="&b_splitjec_data;"/>
+	<Item Name="Split_JEC_MC" Value="&b_splitjec_mc;"/>-->
+	<Item Name="JEC_Version" Value="&jec_version;"/>
+
+	<!-- Systematic uncertainties -->
+	<!-- <Item Name="jersmear_direction" Value="nominal"/> --> <!--nominal/down/up -->
+	<Item Name="jersmear_direction" Value="down"/>
+	<Item Name="Apply_Lumiweights"  Value="&APPLY_LUMIWEIGHTS;"/>
+	<Item Name="Apply_Unflattening" Value="&APPLY_UNFLATTENING;"/>
+	<Item Name="Apply_Weights" Value="&APPLY_WEIGHTS;"/>
+	<Item Name="MC_Weights_Path" Value="&WEIGHT_PATH;"/>
+	<Item Name="METoverPt_cut" Value="&APPLY_METoverPTcut;"/>
+	<Item Name="EtaPhi_cut" Value="&APPLY_EtaPhi_cut;"/>
+	<Item Name="Cut_dir"  Value="&Cut_PATH;"/>
+
+	<Item Name="Trigger_Central"    Value="&TRIGGER_CENTRAL;"/>
+	<Item Name="Trigger_FWD"        Value="&TRIGGER_FWD;"/>
+	
+	<Item Name="Trigger_Single"        Value="&USE_SINGLE_TRIGGER;"/>	
+	<Item Name="Only_BtB"               Value="&ONLY_BACK_TO_BACK;"/>
+	
+	<!-- always apply MET smearing -->
+
+            <!-- tell AnalysisModuleRunner that we use a completely user-defined event format -->
+       <!--     <Item Name="userEventFormat" Value="true" /> -->
+	  <!-- <Item Name="userEventFormat" Value="false" /> -->
+            <!-- the class name of the AnalysisModule subclasses to run: -->
+            <Item Name="AnalysisModule" Value="AnalysisModule_DiJetTrg" /> 
+	    <!--    <Item Name="MCreweight" Value="false" /> -->
+
+        <Item Name="Debug" Value="false" />	    
+
+        </UserConfig>
+    </Cycle>
+</JobConfiguration>

--- a/conf/BaconJets_AnalyseModule_DiJet_Anastasia_JERup.xml
+++ b/conf/BaconJets_AnalyseModule_DiJet_Anastasia_JERup.xml
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd"[
+
+
+<!ENTITY PROOFdir            "/nfs/dust/cms/user/garbersc/forBaconJets/.proof2"> 
+<!ENTITY NEVT                "-1">
+
+<!ENTITY CACHEABLE           "False">
+<!-- <!ENTITY OUTdir              "/nfs/dust/cms/user/garbersc/forBaconJets/17Nov2017/Residuals/Run17F_Data_woHOTVR_woXCON_JEC_V4_2/"> -->
+
+<!ENTITY OUTdir              "/nfs/dust/cms/user/karavdia/JERC/Fall17_17Nov_V4_L2Res_wMPF_CentralTriggersONLY_JERup/">
+
+<!ENTITY b_closuretest       "false">
+<!ENTITY jec_version         "Fall17_17Nov2017_V4">
+<!ENTITY APPLY_WEIGHTS       "false">
+<!ENTITY WEIGHT_PATH         "/nfs/dust/cms/user/multh/JEC/2016ReReco/Residuals/Summer16_03Feb2017_V3/AK4CHS/MC_Reweighted_chsMET_NewTriggerSetup_ForWeights/"> <!-- Change Weight-Path: CENTRAL/FWD -->
+<!ENTITY Cut_PATH            "/nfs/dust/cms/user/multh/JEC/2016ReReco/Residuals/Summer16_03Feb2017_V3/AK4CHS/EtaPhiCut/">
+
+<!ENTITY APPLY_METoverPTcut  "false">  <!--Apply MET Cut-->
+<!ENTITY APPLY_EtaPhi_cut    "false">   <!--Apply Eta Phi cleaning during ECAL problems -->
+<!ENTITY APPLY_LUMIWEIGHTS   "false"> 
+<!ENTITY APPLY_UNFLATTENING  "false">
+<!ENTITY TRIGGER_CENTRAL     "true">  <!--Trigger Flag -->
+<!ENTITY TRIGGER_FWD         "false"> <!--Trigger Flag -->
+
+<!ENTITY ONLY_BACK_TO_BACK "false" >
+<!ENTITY USE_SINGLE_TRIGGER "false" > <!-- if true use the single jet trigger, else the dijet trigger -->
+
+<!ENTITY QCDPt50to80_pythia8_AK4CHS           SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_50to80_EGReg_chsMET.xml">
+<!ENTITY QCDPt80to120_pythia8_AK4CHS          SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_80to120_EGReg_chsMET.xml">
+<!ENTITY QCDPt120to170_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_120to170_EGReg_chsMET.xml">
+<!ENTITY QCDPt170to300_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_170to300_EGReg_chsMET.xml">
+<!ENTITY QCDPt300to470_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_300to470_EGReg_chsMET.xml">
+<!ENTITY QCDPt470to600_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_470to600_EGReg_chsMET.xml">
+<!ENTITY QCDPt600to800_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt600to800_pythia8_AK4CHS_ext1    SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt800to1000_pythia8_AK4CHS        SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt800to1000_pythia8_AK4CHS_ext1   SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt1000to1400_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt1000to1400_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt1400to1800_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt1400to1800_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt1800to2400_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt1800to2400_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt2400to3200_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt2400to3200_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt3200toInf_pythia8_AK4CHS        SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_3200toInf_EGReg_chsMET.xml">
+
+
+<!--
+<!ENTITY DATA_RunB_promptReco_2017 SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17_clean160118/CMSSW_9_4_1/src/UHH2/common/datasets/RunII_94X_v1/">
+
+<!ENTITY DATA_RunC_promptReco_2017 SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17_clean160118/CMSSW_9_4_1/src/UHH2/common/datasets/RunII_94X_v1/JetHT_RunC_17Nov17_v1.xml">
+
+<!ENTITY DATA_RunE_promptReco_2017 SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17_clean300118/CMSSW_9_4_1/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunE_17Nov2017.xml">
+
+
+-->
+<!ENTITY DATA_RunF_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunF_17Nov2017_wCHSMETfixed.xml">
+
+<!ENTITY DATA_RunD_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunD_17Nov2017_wCHSMETfixed.xml">
+
+<!ENTITY QCDPt15to7000 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/MC_QCD_Flat2017_pythia8_wCHSMETfixed.xml">
+
+<!ENTITY DATA_RunE_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunE_17Nov17_v1.xml">
+
+]>
+
+
+<!--
+<ConfigParse NEventsBreak="0" FileSplit="10" AutoResubmit="5"/>
+<ConfigSGE RAM ="2" DISK ="3" Mail="xxx@desy.de" Notification="as" Workdir="/nfs/dust/cms/user/karavdia/JERC/workdir_Data_Run17_wCHSMETfix_4_JERup_2"/>
+-->
+
+<!-- OutputLevel controls which messages are printed; set to VERBOSE or DEBUG for more verbosity, to WARNING or ERROR or INFO for less -->
+ <JobConfiguration JobName="ExampleCycleJob" OutputLevel="INFO"> 
+    <Library Name="libSUHH2BaconJets"/>
+    <Package Name="SUHH2BaconJets.par" />
+
+ <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&OUTdir;/" PostFix="" TargetLumi="8317" > 
+<!-- <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&OUTdir;/" PostFix="" TargetLumi="4553" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="15" > -->
+
+
+<!-- <InputData Lumi="0.518" NEventsMax="&NEVT;" Type="MC" Version="QCDPt50to80_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt50to80_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="5.283" NEventsMax="&NEVT;" Type="MC" Version="QCDPt80to120_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt80to120_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="26.443" NEventsMax="&NEVT;" Type="MC" Version="QCDPt120to170_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt120to170_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="125.998" NEventsMax="&NEVT;" Type="MC" Version="QCDPt170to300_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt170to300_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="2841.593" NEventsMax="&NEVT;" Type="MC" Version="QCDPt300to470_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt300to470_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="6100.393" NEventsMax="&NEVT;" Type="MC" Version="QCDPt470to600_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt470to600_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="72315.548" NEventsMax="&NEVT;" Type="MC" Version="QCDPt600to800_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt600to800_pythia8_AK4CHS; &QCDPt600to800_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="609694.175" NEventsMax="&NEVT;" Type="MC" Version="QCDPt800to1000_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt800to1000_pythia8_AK4CHS; &QCDPt800to1000_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="1059141.459" NEventsMax="&NEVT;" Type="MC" Version="QCDPt1000to1400_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt1000to1400_pythia8_AK4CHS; &QCDPt1000to1400_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="3394810.420" NEventsMax="&NEVT;" Type="MC" Version="QCDPt1400to1800_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt1400to1800_pythia8_AK4CHS; &QCDPt1400to1800_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="16852065.807" NEventsMax="&NEVT;" Type="MC" Version="QCDPt1800to2400_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt1800to2400_pythia8_AK4CHS; &QCDPt1800to2400_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="144125092.792" NEventsMax="&NEVT;" Type="MC" Version="QCDPt2400to3200_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt2400to3200_pythia8_AK4CHS; &QCDPt2400to3200_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="2362102209.193" NEventsMax="&NEVT;" Type="MC" Version="QCDPt3200toInf_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt3200toInf_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+
+
+<InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="QCDPt15to7000" Cacheable="&CACHEABLE;">
+          &QCDPt15to7000;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+     </InputData>
+
+<!--
+<InputData Lumi="1" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunD_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunD_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+
+
+<InputData Lumi="1" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunF_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunF_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+
+<InputData Lumi="1" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunE_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunE_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+-->
+    <UserConfig>
+      <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices"/>
+      <!-- <Item Name="GenParticleCollection"   Value="GenParticles"/> -->
+<!--      <Item Name="GenParticleCollection"   Value="slimmedJets"/> --> <!-- bullshit for MC with missing GenParticles -->
+      <Item Name="ElectronCollection"      Value="slimmedElectronsUSER"/> <!-- change depending on 2016 MC or 17 data!!! -->
+      <Item Name="MuonCollection"          Value="slimmedMuonsUSER"/>
+      <Item Name="TauCollection"           Value="slimmedTaus"/>
+      <!-- AK4CHS -->
+      <Item Name="JetCollection"           Value="slimmedJets"/>
+      <Item Name="JetLabel"                Value="AK4CHS"/> 
+      <Item Name="GenJetCollection"        Value="slimmedGenJets"/>    <!-- bullshit for MC with missing GenParticles -->
+      <!-- <Item Name="METName"                 Value="slMETsCHS"/> -->
+      <Item Name="METName"                 Value="slimmedMETs"/>
+      
+      <!-- <Item Name="lumi_file" Value="/nfs/dust/cms/user/garbersc/UHH2_17/CMSSW_9_2_7_patch1/src/UHH2/common/data/Cert_13TeV_2017_HCAL_DCS_GOOD_11Jul.root"/> -->
+
+       <Item Name="lumi_file" Value="/nfs/dust/cms/user/garbersc/UHH2_17_clean300118/CMSSW_9_4_1/src/UHH2/common/data/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.root"/>
+     
+      <!--
+      	 <Item Name="pileup_directory"           Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/>
+	 <Item Name="pileup_directory_data"      Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/>
+	 <Item Name="pileup_directory_data_up"   Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/>
+	 <Item Name="pileup_directory_data_down" Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/> 
+	 <Item Name="pileup_directory_data"      Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/800pb/nPU_minBiasXsec71300.root"/>
+	 <Item Name="pileup_directory_data_up"   Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/800pb/nPU_minBiasXsec80000.root"/>
+	 <Item Name="pileup_directory_data_down" Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/800pb/nPU_minBiasXsec58000.root"/> -->
+
+
+      <Item Name="lumihists_lumi_per_bin" Value="50."/>
+
+
+<!--      <Item Name="use_sframe_weight" Value="true"/> -->  <!--false-->
+      <Item Name="use_sframe_weight" Value="false"/>
+
+      <Item Name="trigger40" Value="HLT_DiPFJetAve40_v*"/>
+      <Item Name="trigger60" Value="HLT_DiPFJetAve60_v*"/>
+      <Item Name="trigger80" Value="HLT_DiPFJetAve80_v*"/>
+      <Item Name="trigger140" Value="HLT_DiPFJetAve140_v*"/>
+      <Item Name="trigger200" Value="HLT_DiPFJetAve200_v*"/>
+      <Item Name="trigger260" Value="HLT_DiPFJetAve260_v*"/>
+      <Item Name="trigger320" Value="HLT_DiPFJetAve320_v*"/>
+      <Item Name="trigger400" Value="HLT_DiPFJetAve400_v*"/>
+      <Item Name="trigger500" Value="HLT_DiPFJetAve500_v*"/>
+
+      <Item Name="trigger60_HFJEC" Value="HLT_DiPFJetAve60_HFJEC_v*"/>
+      <Item Name="trigger80_HFJEC" Value="HLT_DiPFJetAve80_HFJEC_v*"/>
+      <Item Name="trigger100_HFJEC" Value="HLT_DiPFJetAve100_HFJEC_v*"/>
+      <Item Name="trigger160_HFJEC" Value="HLT_DiPFJetAve160_HFJEC_v*"/>
+      <Item Name="trigger220_HFJEC" Value="HLT_DiPFJetAve220_HFJEC_v*"/>
+      <Item Name="trigger300_HFJEC" Value="HLT_DiPFJetAve300_HFJEC_v*"/>      
+
+	<!-- Closure test? -->
+	<Item Name="ClosureTest" Value="&b_closuretest;"/>
+	<!--<Item Name="Split_JEC_DATA" Value="&b_splitjec_data;"/>
+	<Item Name="Split_JEC_MC" Value="&b_splitjec_mc;"/>-->
+	<Item Name="JEC_Version" Value="&jec_version;"/>
+
+	<!-- Systematic uncertainties -->
+	<!-- <Item Name="jersmear_direction" Value="nominal"/> --> <!--nominal/down/up -->
+	<Item Name="jersmear_direction" Value="up"/>
+	<Item Name="Apply_Lumiweights"  Value="&APPLY_LUMIWEIGHTS;"/>
+	<Item Name="Apply_Unflattening" Value="&APPLY_UNFLATTENING;"/>
+	<Item Name="Apply_Weights" Value="&APPLY_WEIGHTS;"/>
+	<Item Name="MC_Weights_Path" Value="&WEIGHT_PATH;"/>
+	<Item Name="METoverPt_cut" Value="&APPLY_METoverPTcut;"/>
+	<Item Name="EtaPhi_cut" Value="&APPLY_EtaPhi_cut;"/>
+	<Item Name="Cut_dir"  Value="&Cut_PATH;"/>
+
+	<Item Name="Trigger_Central"    Value="&TRIGGER_CENTRAL;"/>
+	<Item Name="Trigger_FWD"        Value="&TRIGGER_FWD;"/>
+	
+	<Item Name="Trigger_Single"        Value="&USE_SINGLE_TRIGGER;"/>	
+	<Item Name="Only_BtB"               Value="&ONLY_BACK_TO_BACK;"/>
+	
+	<!-- always apply MET smearing -->
+
+            <!-- tell AnalysisModuleRunner that we use a completely user-defined event format -->
+       <!--     <Item Name="userEventFormat" Value="true" /> -->
+	  <!-- <Item Name="userEventFormat" Value="false" /> -->
+            <!-- the class name of the AnalysisModule subclasses to run: -->
+            <Item Name="AnalysisModule" Value="AnalysisModule_DiJetTrg" /> 
+	    <!--    <Item Name="MCreweight" Value="false" /> -->
+
+        <Item Name="Debug" Value="false" />	    
+
+        </UserConfig>
+    </Cycle>
+</JobConfiguration>

--- a/conf/BaconJets_AnalyseModule_SiJet_Anastasia.xml
+++ b/conf/BaconJets_AnalyseModule_SiJet_Anastasia.xml
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd"[
+
+
+<!ENTITY PROOFdir            "/nfs/dust/cms/user/garbersc/forBaconJets/.proof2"> 
+<!ENTITY NEVT                "-1">
+
+<!ENTITY CACHEABLE           "False">
+<!ENTITY OUTdir              "/nfs/dust/cms/user/karavdia/JERC/Fall17_17Nov_V4_L2Res_wMPF_CentralTriggersOnly_SingleJet_Fix/">
+
+<!ENTITY b_closuretest       "false">
+<!ENTITY jec_version         "Fall17_17Nov2017_V4">
+<!ENTITY APPLY_WEIGHTS       "false">
+<!ENTITY WEIGHT_PATH         "/nfs/dust/cms/user/multh/JEC/2016ReReco/Residuals/Summer16_03Feb2017_V3/AK4CHS/MC_Reweighted_chsMET_NewTriggerSetup_ForWeights/"> <!-- Change Weight-Path: CENTRAL/FWD -->
+<!ENTITY Cut_PATH            "/nfs/dust/cms/user/multh/JEC/2016ReReco/Residuals/Summer16_03Feb2017_V3/AK4CHS/EtaPhiCut/">
+
+<!ENTITY APPLY_METoverPTcut  "false">  <!--Apply MET Cut-->
+<!ENTITY APPLY_EtaPhi_cut    "false">   <!--Apply Eta Phi cleaning during ECAL problems -->
+<!ENTITY APPLY_LUMIWEIGHTS   "false"> 
+<!ENTITY APPLY_UNFLATTENING  "false">
+<!ENTITY TRIGGER_CENTRAL     "true">  <!--Trigger Flag -->
+<!ENTITY TRIGGER_FWD         "false"> <!--Trigger Flag -->
+
+<!ENTITY ONLY_BACK_TO_BACK "false" >
+
+<!ENTITY USE_SINGLE_TRIGGER "true" > <!-- if true use the single jet trigger, else the dijet trigger -->
+
+<!ENTITY QCDPt50to80_pythia8_AK4CHS           SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_50to80_EGReg_chsMET.xml">
+<!ENTITY QCDPt80to120_pythia8_AK4CHS          SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_80to120_EGReg_chsMET.xml">
+<!ENTITY QCDPt120to170_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_120to170_EGReg_chsMET.xml">
+<!ENTITY QCDPt170to300_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_170to300_EGReg_chsMET.xml">
+<!ENTITY QCDPt300to470_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_300to470_EGReg_chsMET.xml">
+<!ENTITY QCDPt470to600_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_470to600_EGReg_chsMET.xml">
+<!ENTITY QCDPt600to800_pythia8_AK4CHS         SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt600to800_pythia8_AK4CHS_ext1    SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt800to1000_pythia8_AK4CHS        SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt800to1000_pythia8_AK4CHS_ext1   SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt1000to1400_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt1000to1400_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt1400to1800_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt1400to1800_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt1800to2400_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt1800to2400_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt2400to3200_pythia8_AK4CHS       SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8.xml">
+<!ENTITY QCDPt2400to3200_pythia8_AK4CHS_ext1  SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8_ext1.xml">
+<!ENTITY QCDPt3200toInf_pythia8_AK4CHS        SYSTEM "/nfs/dust/cms/user/multh/CMSSW_8_0_26_patch2/src/UHH2/common/datasets/RunII_80X_v3_EGReg/MC_QCD_Pt_3200toInf_EGReg_chsMET.xml">
+
+
+<!ENTITY DATA_RunB_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunB_17Nov2017_wCHSMETfixed.xml">
+
+<!ENTITY DATA_RunC_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunC_17Nov2017_wCHSMETfixed.xml">
+
+<!ENTITY DATA_RunD_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunD_17Nov2017_wCHSMETfixed.xml">
+
+
+<!ENTITY QCDPt15to7000 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/MC_QCD_Flat2017_pythia8_wCHSMETfixed.xml">
+
+]>
+
+
+<!--
+<ConfigParse NEventsBreak="0" FileSplit="10" AutoResubmit="5"/>
+<ConfigSGE RAM ="4" DISK ="3" Mail="xxx@desy.de" Notification="as" Workdir="/nfs/dust/cms/user/karavdia/JERC/workdir_Data_Run17_wCHSMETfix_SingleJet_FIX"/>
+-->
+
+<!-- OutputLevel controls which messages are printed; set to VERBOSE or DEBUG for more verbosity, to WARNING or ERROR or INFO for less -->
+ <JobConfiguration JobName="ExampleCycleJob" OutputLevel="INFO"> 
+    <Library Name="libSUHH2BaconJets"/>
+    <Package Name="SUHH2BaconJets.par" />
+
+ <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&OUTdir;/" PostFix="" TargetLumi="8317" > 
+<!-- <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&OUTdir;/" PostFix="" TargetLumi="4553" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="15" > -->
+
+
+<!-- <InputData Lumi="0.518" NEventsMax="&NEVT;" Type="MC" Version="QCDPt50to80_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt50to80_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="5.283" NEventsMax="&NEVT;" Type="MC" Version="QCDPt80to120_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt80to120_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="26.443" NEventsMax="&NEVT;" Type="MC" Version="QCDPt120to170_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt120to170_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="125.998" NEventsMax="&NEVT;" Type="MC" Version="QCDPt170to300_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt170to300_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="2841.593" NEventsMax="&NEVT;" Type="MC" Version="QCDPt300to470_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt300to470_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="6100.393" NEventsMax="&NEVT;" Type="MC" Version="QCDPt470to600_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt470to600_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="72315.548" NEventsMax="&NEVT;" Type="MC" Version="QCDPt600to800_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt600to800_pythia8_AK4CHS; &QCDPt600to800_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="609694.175" NEventsMax="&NEVT;" Type="MC" Version="QCDPt800to1000_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt800to1000_pythia8_AK4CHS; &QCDPt800to1000_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="1059141.459" NEventsMax="&NEVT;" Type="MC" Version="QCDPt1000to1400_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt1000to1400_pythia8_AK4CHS; &QCDPt1000to1400_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="3394810.420" NEventsMax="&NEVT;" Type="MC" Version="QCDPt1400to1800_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt1400to1800_pythia8_AK4CHS; &QCDPt1400to1800_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="16852065.807" NEventsMax="&NEVT;" Type="MC" Version="QCDPt1800to2400_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt1800to2400_pythia8_AK4CHS; &QCDPt1800to2400_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="144125092.792" NEventsMax="&NEVT;" Type="MC" Version="QCDPt2400to3200_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt2400to3200_pythia8_AK4CHS; &QCDPt2400to3200_pythia8_AK4CHS_ext1; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!-- <InputData Lumi="2362102209.193" NEventsMax="&NEVT;" Type="MC" Version="QCDPt3200toInf_pythia8_AK4CHS" Cacheable="&CACHEABLE;"> -->
+<!--           &QCDPt3200toInf_pythia8_AK4CHS; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!--      </InputData> -->
+<!--
+<InputData Lumi="1" NEventsMax="&NEVT;" Type="MC" Version="QCDPt15to7000" Cacheable="&CACHEABLE;">
+          &QCDPt15to7000;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+     </InputData>
+
+-->
+<InputData Lumi="62988012" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunB_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunB_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+
+<InputData Lumi="96264601" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunC_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunC_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+
+<InputData Lumi="36311468" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunD_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunD_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+
+
+    <UserConfig>
+      <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices"/>
+      <Item Name="GenParticleCollection"   Value="GenParticles"/>
+      <Item Name="ElectronCollection"      Value="slimmedElectronsUSER"/> <!-- change depending on 2016 MC or 17 data!!! -->
+      <Item Name="MuonCollection"          Value="slimmedMuonsUSER"/>
+      <Item Name="TauCollection"           Value="slimmedTaus"/>
+      <!-- AK4CHS -->
+      <Item Name="JetCollection"           Value="slimmedJets"/>
+      <Item Name="JetLabel"                Value="AK4CHS"/> 
+      <Item Name="GenJetCollection"        Value="slimmedGenJets"/>
+      <!-- <Item Name="METName"                 Value="slMETsCHS"/> -->
+     <Item Name="METName"                 Value="slimmedMETs"/>     
+     
+      <!-- <Item Name="lumi_file" Value="/nfs/dust/cms/user/garbersc/UHH2_17/CMSSW_9_2_7_patch1/src/UHH2/common/data/Cert_13TeV_2017_HCAL_DCS_GOOD_11Jul.root"/> -->
+
+       <Item Name="lumi_file" Value="/nfs/dust/cms/user/garbersc/UHH2_17_clean300118/CMSSW_9_4_1/src/UHH2/common/data/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.root"/>
+     
+      <!--
+      	 <Item Name="pileup_directory"           Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/>
+	 <Item Name="pileup_directory_data"      Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/>
+	 <Item Name="pileup_directory_data_up"   Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/>
+	 <Item Name="pileup_directory_data_down" Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/PileUP_MC_pythia8_PUFlat.root"/> 
+	 <Item Name="pileup_directory_data"      Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/800pb/nPU_minBiasXsec71300.root"/>
+	 <Item Name="pileup_directory_data_up"   Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/800pb/nPU_minBiasXsec80000.root"/>
+	 <Item Name="pileup_directory_data_down" Value="/afs/desy.de/user/k/karavdia/CMSSW_8_0_20/src/UHH2/BaconJets/data/PileUp/80X/800pb/nPU_minBiasXsec58000.root"/> -->
+
+
+      <Item Name="lumihists_lumi_per_bin" Value="50."/>
+
+
+      <Item Name="use_sframe_weight" Value="true"/>  <!--false-->
+
+      <Item Name="trigger40" Value="HLT_PFJet40_v*"/>
+      <Item Name="trigger60" Value="HLT_PFJet60_v*"/>
+      <Item Name="trigger80" Value="HLT_PFJet80_v*"/>
+      <Item Name="trigger140" Value="HLT_PFJet140_v*"/>
+      <Item Name="trigger200" Value="HLT_PFJet200_v*"/>
+      <Item Name="trigger260" Value="HLT_PFJet260_v*"/>
+      <Item Name="trigger320" Value="HLT_PFJet320_v*"/>
+      <Item Name="trigger400" Value="HLT_PFJet400_v*"/>
+      <Item Name="trigger450" Value="HLT_PFJet450_v*"/>     
+      <Item Name="trigger500" Value="HLT_PFJet500_v*"/>
+
+      <Item Name="trigger40_fwd" Value="HLT_PFJetFwd40_v*"/>     
+      <Item Name="trigger60_fwd" Value="HLT_PFJetFwd60_v*"/>
+      <Item Name="trigger80_fwd" Value="HLT_PFJetFwd80_v*"/>
+      <Item Name="trigger140_fwd" Value="HLT_PFJetFwd140_v*"/>
+      <Item Name="trigger200_fwd" Value="HLT_PFJetFwd200_v*"/>
+      <Item Name="trigger260_fwd" Value="HLT_PFJetFwd260_v*"/>
+      <Item Name="trigger320_fwd" Value="HLT_PFJetFwd320_v*"/>
+      
+      <Item Name="trigger400_fwd" Value="HLT_PFJetFwd400_v*"/>
+      <Item Name="trigger450_fwd" Value="HLT_PFJetFwd450_v*"/>
+      <Item Name="trigger500_fwd" Value="HLT_PFJetFwd500_v*"/>
+      
+      <Item Name="triggerDi40" Value="HLT_DiPFJetAve40_v*"/>
+      <Item Name="triggerDi60" Value="HLT_DiPFJetAve60_v*"/>
+      <Item Name="triggerDi80" Value="HLT_DiPFJetAve80_v*"/>
+      <Item Name="triggerDi140" Value="HLT_DiPFJetAve140_v*"/>
+      <Item Name="triggerDi200" Value="HLT_DiPFJetAve200_v*"/>
+      <Item Name="triggerDi260" Value="HLT_DiPFJetAve260_v*"/>
+      <Item Name="triggerDi320" Value="HLT_DiPFJetAve320_v*"/>
+      <Item Name="triggerDio400" Value="HLT_DiPFJetAve400_v*"/>
+      <Item Name="triggerDi500" Value="HLT_DiPFJetAve500_v*"/>
+
+      <Item Name="trigger60_HFJEC" Value="HLT_DiPFJetAve60_HFJEC_v*"/>
+      <Item Name="trigger80_HFJEC" Value="HLT_DiPFJetAve80_HFJEC_v*"/>
+      <Item Name="trigger100_HFJEC" Value="HLT_DiPFJetAve100_HFJEC_v*"/>
+      <Item Name="trigger160_HFJEC" Value="HLT_DiPFJetAve160_HFJEC_v*"/>
+      <Item Name="trigger220_HFJEC" Value="HLT_DiPFJetAve220_HFJEC_v*"/>
+      
+	<!-- Closure test? -->
+	<Item Name="ClosureTest" Value="&b_closuretest;"/>
+	<!--<Item Name="Split_JEC_DATA" Value="&b_splitjec_data;"/>
+	<Item Name="Split_JEC_MC" Value="&b_splitjec_mc;"/>-->
+	<Item Name="JEC_Version" Value="&jec_version;"/>
+
+	<!-- Systematic uncertainties -->
+	<Item Name="jersmear_direction" Value="nominal"/> <!--nominal/down/up -->
+
+	<Item Name="Apply_Lumiweights"  Value="&APPLY_LUMIWEIGHTS;"/>
+	<Item Name="Apply_Unflattening" Value="&APPLY_UNFLATTENING;"/>
+	<Item Name="Apply_Weights" Value="&APPLY_WEIGHTS;"/>
+	<Item Name="MC_Weights_Path" Value="&WEIGHT_PATH;"/>
+	<Item Name="METoverPt_cut" Value="&APPLY_METoverPTcut;"/>
+	<Item Name="EtaPhi_cut" Value="&APPLY_EtaPhi_cut;"/>
+	<Item Name="Cut_dir"  Value="&Cut_PATH;"/>
+
+	<Item Name="Trigger_Central"    Value="&TRIGGER_CENTRAL;"/>
+	<Item Name="Trigger_FWD"        Value="&TRIGGER_FWD;"/>
+	
+	<Item Name="Trigger_Single"        Value="&USE_SINGLE_TRIGGER;"/>	
+	<Item Name="Only_BtB"               Value="&ONLY_BACK_TO_BACK;"/>
+
+	<!-- always apply MET smearing -->
+
+            <!-- tell AnalysisModuleRunner that we use a completely user-defined event format -->
+       <!--     <Item Name="userEventFormat" Value="true" /> -->
+	  <!-- <Item Name="userEventFormat" Value="false" /> -->
+            <!-- the class name of the AnalysisModule subclasses to run: -->
+            <Item Name="AnalysisModule" Value="AnalysisModule_SiJetTrg" /> 
+	<!--    <Item Name="MCreweight" Value="false" /> -->  
+
+        <Item Name="Debug" Value="false" />
+	
+        </UserConfig>
+    </Cycle>
+</JobConfiguration>

--- a/conf/BaconJets_AnalyseModule_noPtBinningToDeriveThresholds_Si_Anastasia.xml
+++ b/conf/BaconJets_AnalyseModule_noPtBinningToDeriveThresholds_Si_Anastasia.xml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE JobConfiguration PUBLIC "" "JobConfig.dtd"[
+
+
+<!ENTITY PROOFdir            "/nfs/dust/cms/user/garbersc/forBaconJets/.proof2"> 
+<!ENTITY NEVT                "-1">
+
+<!ENTITY CACHEABLE           "False">
+<!-- <!ENTITY OUTdir              "/nfs/dust/cms/user/garbersc/forBaconJets/17Nov2017/Residuals/Run17BC_Data_woHOTVR_woXCON_JEC_V4_DeriveThresholds_SiTrg_central/"> -->
+<!ENTITY OUTdir              "/nfs/dust/cms/user/karavdia/JERC/Fall17_17Nov_V4_L2Res_wMPF_CentralTriggersOnly_SingleJet_ForTriggerThresholds/">
+
+<!ENTITY b_closuretest       "false">
+<!ENTITY jec_version         "Fall17_17Nov2017_V4"> 
+<!ENTITY APPLY_WEIGHTS       "false">
+<!ENTITY WEIGHT_PATH         "/nfs/dust/cms/user/multh/JEC/2016ReReco/Residuals/Summer16_03Feb2017_V3/AK4CHS/MC_Reweighted_chsMET_NewTriggerSetup_ForWeights/"> <!-- Change Weight-Path: CENTRAL/FWD -->
+<!ENTITY Cut_PATH            "/nfs/dust/cms/user/multh/JEC/2016ReReco/Residuals/Summer16_03Feb2017_V3/AK4CHS/EtaPhiCut/">
+
+<!ENTITY APPLY_METoverPTcut  "false">  <!--Apply MET Cut-->
+<!ENTITY APPLY_EtaPhi_cut    "false">   <!--Apply Eta Phi cleaning during ECAL problems -->
+<!ENTITY APPLY_LUMIWEIGHTS   "false"> 
+<!ENTITY APPLY_UNFLATTENING  "false">
+<!ENTITY TRIGGER_CENTRAL     "true">  <!--Trigger Flag -->
+<!ENTITY TRIGGER_FWD         "false"> <!--Trigger Flag -->
+
+<!ENTITY TRIGGER_SINGLEMUON  "false"> <!--Trigger Flag -->
+<!ENTITY TRIGGER_SINGLEMUON_NAME  "Mu27"> <!--Trigger Flag -->
+
+<!ENTITY ONLY_BACK_TO_BACK "true" >
+<!ENTITY DO_TRG_OBJ_JET_MATCHING "false" >
+
+<!ENTITY USE_SINGLE_TRIGGER "true" > <!-- if true use the single jet trigger, else the dijet trigger -->
+<!--
+<!ENTITY DATA_RunB_promptReco_2017 SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17_clean300118/CMSSW_9_4_1/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunB_17Nov2017_wCHSMETfixed.xml">
+
+<!ENTITY DATA_RunC_promptReco_2017 SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17_clean300118/CMSSW_9_4_1/src/UHH2/common/datasets/RunII_94X_v1/JetHT_RunC_17Nov17_v1.xml">
+
+
+<!ENTITY DATA_RunD_promptReco_2017 SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17_clean300118/CMSSW_9_4_1/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunD_17Nov2017_wCHSMETfixed.xml">
+
+<!ENTITY DATA_RunE_promptReco_2017 SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17_clean300118/CMSSW_9_4_1/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunE_17Nov2017.xml">
+
+
+
+<!ENTITY DATA_RunB_promptReco_2017_SingleMuon SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17/CMSSW_9_2_7_patch1/src/UHH2/common/datasets/RunII_92X_v1/DATA_SingleMuon_Run2017B_PromptReco.xml">
+
+<!ENTITY DATA_RunC_promptReco_2017_SingleMuon SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17/CMSSW_9_2_7_patch1/src/UHH2/common/datasets/RunII_92X_v1/DATA_SingleMuon_Run2017C_PromtReco_v1.xml">
+
+<!ENTITY DATA_RunD_promptReco_2017_SingleMuon SYSTEM "/nfs/dust/cms/user/garbersc/UHH2_17/CMSSW_9_2_7_patch1/src/UHH2/common/datasets/RunII_92X_v1/DATA_SingleMuon_Run2017D_PromtReco_v1.xml">
+-->
+
+<!ENTITY DATA_RunB_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunB_17Nov2017_wCHSMETfixed.xml">
+
+<!ENTITY DATA_RunC_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunC_17Nov2017_wCHSMETfixed.xml">
+
+<!ENTITY DATA_RunD_promptReco_2017 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/DATA_JetHT_RunD_17Nov2017_wCHSMETfixed.xml">
+
+
+<!ENTITY QCDPt15to7000 SYSTEM "/nfs/dust/cms/user/karavdia/CMSSW_9_4_2/src/UHH2/common/datasets/RunII_94X_v1_woHOTVR_woXCONE/MC_QCD_Flat2017_pythia8_wCHSMETfixed.xml">
+
+
+]>
+
+
+<!--
+<ConfigParse NEventsBreak="0" FileSplit="10" AutoResubmit="5"/>
+<ConfigSGE RAM ="4" DISK ="3" Mail="xxx@desy.de" Notification="as" Workdir="/nfs/dust/cms/user/karavdia/JERC/workdir_triggerThs"/>
+-->
+
+<!-- OutputLevel controls which messages are printed; set to VERBOSE or DEBUG for more verbosity, to WARNING or ERROR or INFO for less -->
+ <JobConfiguration JobName="ExampleCycleJob" OutputLevel="INFO"> 
+    <Library Name="libSUHH2BaconJets"/>
+    <Package Name="SUHH2BaconJets.par" />
+
+ <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&OUTdir;/" PostFix="" TargetLumi="8317" > 
+<!-- <Cycle Name="uhh2::AnalysisModuleRunner" OutputDirectory="&OUTdir;/" PostFix="" TargetLumi="4553" RunMode="PROOF" ProofServer="lite://" ProofWorkDir="&PROOFdir;/" ProofNodes="15" > -->
+
+<InputData Lumi="62988012" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunB_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunB_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+
+<InputData Lumi="96264601" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunC_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunC_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+
+<InputData Lumi="36311468" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunD_17Nov17_2017" Cacheable="&CACHEABLE;">
+          &DATA_RunD_promptReco_2017;
+          <InputTree Name="AnalysisTree"/>
+          <OutputTree Name="AnalysisTree"/>
+</InputData>
+
+<!-- <InputData Lumi="76958681" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunE_17Nov17_2017" Cacheable="&CACHEABLE;"> -->
+<!--           &DATA_RunE_promptReco_2017; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!-- </InputData> -->
+
+
+<!-- <InputData Lumi="1" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunB_promptReco_2017_SingleMuon" Cacheable="&CACHEABLE;"> -->
+<!--           &DATA_RunB_promptReco_2017_SingleMuon; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!-- </InputData> -->
+
+<!-- <InputData Lumi="1" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunC_promptReco_2017_SingleMuon" Cacheable="&CACHEABLE;"> -->
+<!--           &DATA_RunC_promptReco_2017_SingleMuon; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!-- </InputData> -->
+
+<!-- <InputData Lumi="1" NEventsMax="&NEVT;" Type="DATA" Version="DATA_RunD_promptReco_2017_SingleMuon" Cacheable="&CACHEABLE;"> -->
+<!--           &DATA_RunD_promptReco_2017_SingleMuon; -->
+<!--           <InputTree Name="AnalysisTree"/> -->
+<!--           <OutputTree Name="AnalysisTree"/> -->
+<!-- </InputData> -->
+
+
+    <UserConfig>
+      <Item Name="PrimaryVertexCollection" Value="offlineSlimmedPrimaryVertices"/>
+      <Item Name="GenParticleCollection"   Value="GenParticles"/>
+      <Item Name="ElectronCollection"      Value="slimmedElectronsUSER"/> <!-- change depending on 2016 MC or 17 data!!! or ntuplewriter version XD -->
+      <Item Name="MuonCollection"          Value="slimmedMuonsUSER"/>
+      <Item Name="TauCollection"           Value="slimmedTaus"/>
+      <!-- AK4CHS -->
+      <Item Name="JetCollection"           Value="slimmedJets"/>
+      <Item Name="JetLabel"                Value="AK4CHS"/> 
+
+      <Item Name="GenJetCollection"        Value="slimmedGenJets"/>
+      <!-- <Item Name="METName"                 Value="slMETsCHS"/> -->
+     <Item Name="METName"                 Value="slimmedMETs"/>     
+     
+       <Item Name="lumi_file" Value="/nfs/dust/cms/user/garbersc/UHH2_17/CMSSW_9_2_7_patch1/src/UHH2/common/data/Cert_294927-304507_13TeV_PromptReco_Collisions17_JSON.root"/>
+
+       <Item Name="lumihists_lumi_per_bin" Value="500."/>
+
+
+      <Item Name="use_sframe_weight" Value="true"/>  <!--false-->
+      
+      <Item Name="triggerSiMu" Value="HLT_&TRIGGER_SINGLEMUON_NAME;_v*"/>
+      <Item Name="triggerSiMu_DirName" Value="HLT_&TRIGGER_SINGLEMUON_NAME;"/>
+      
+      <Item Name="minBias" Value="HLT_L1MinimumBiasHF_OR_v*"/>
+      <Item Name="trigger40" Value="HLT_PFJet40_v*"/>
+      <Item Name="trigger60" Value="HLT_PFJet60_v*"/>
+      <Item Name="trigger80" Value="HLT_PFJet80_v*"/>
+      <Item Name="trigger140" Value="HLT_PFJet140_v*"/>
+      <Item Name="trigger200" Value="HLT_PFJet200_v*"/>
+      <Item Name="trigger260" Value="HLT_PFJet260_v*"/>
+      <Item Name="trigger320" Value="HLT_PFJet320_v*"/>
+      <Item Name="trigger400" Value="HLT_PFJet400_v*"/>
+      <Item Name="trigger450" Value="HLT_PFJet450_v*"/>
+      <Item Name="trigger500" Value="HLT_PFJet500_v*"/>
+
+      <Item Name="trigger40_fwd" Value="HLT_PFJetFwd40_v*"/>     
+      <Item Name="trigger60_fwd" Value="HLT_PFJetFwd60_v*"/>
+      <Item Name="trigger80_fwd" Value="HLT_PFJetFwd80_v*"/>
+      <Item Name="trigger140_fwd" Value="HLT_PFJetFwd140_v*"/>
+      <Item Name="trigger200_fwd" Value="HLT_PFJetFwd200_v*"/>
+      <Item Name="trigger260_fwd" Value="HLT_PFJetFwd260_v*"/>
+      <Item Name="trigger320_fwd" Value="HLT_PFJetFwd320_v*"/>
+      
+      <Item Name="trigger400_fwd" Value="HLT_PFJetFwd400_v*"/>
+      <Item Name="trigger450_fwd" Value="HLT_PFJetFwd450_v*"/>
+      <Item Name="trigger500_fwd" Value="HLT_PFJetFwd500_v*"/>
+      
+      <Item Name="triggerDi40" Value="HLT_DiPFJetAve40_v*"/>
+      <Item Name="triggerDi60" Value="HLT_DiPFJetAve60_v*"/>
+      <Item Name="triggerDi80" Value="HLT_DiPFJetAve80_v*"/>
+      <Item Name="triggerDi140" Value="HLT_DiPFJetAve140_v*"/>
+      <Item Name="triggerDi200" Value="HLT_DiPFJetAve200_v*"/>
+      <Item Name="triggerDi260" Value="HLT_DiPFJetAve260_v*"/>
+      <Item Name="triggerDi320" Value="HLT_DiPFJetAve320_v*"/>
+      <Item Name="triggerDi400" Value="HLT_DiPFJetAve400_v*"/>
+      <Item Name="triggerDi500" Value="HLT_DiPFJetAve500_v*"/>
+
+      <Item Name="trigger60_HFJEC" Value="HLT_DiPFJetAve60_HFJEC_v*"/>
+      <Item Name="trigger80_HFJEC" Value="HLT_DiPFJetAve80_HFJEC_v*"/>
+      <Item Name="trigger100_HFJEC" Value="HLT_DiPFJetAve100_HFJEC_v*"/>
+      <Item Name="trigger160_HFJEC" Value="HLT_DiPFJetAve160_HFJEC_v*"/>
+      <Item Name="trigger220_HFJEC" Value="HLT_DiPFJetAve220_HFJEC_v*"/>
+      <Item Name="trigger300_HFJEC" Value="HLT_DiPFJetAve300_HFJEC_v*"/>
+      
+	<!-- Closure test? -->
+	<Item Name="ClosureTest" Value="&b_closuretest;"/>
+	<!--<Item Name="Split_JEC_DATA" Value="&b_splitjec_data;"/>
+	<Item Name="Split_JEC_MC" Value="&b_splitjec_mc;"/>-->
+	<Item Name="JEC_Version" Value="&jec_version;"/>
+
+	<!-- Systematic uncertainties -->
+	<Item Name="jersmear_direction" Value="nominal"/> <!--nominal/down/up -->
+
+	<Item Name="Apply_Lumiweights"  Value="&APPLY_LUMIWEIGHTS;"/>
+	<Item Name="Apply_Unflattening" Value="&APPLY_UNFLATTENING;"/>
+	<Item Name="Apply_Weights" Value="&APPLY_WEIGHTS;"/>
+	<Item Name="MC_Weights_Path" Value="&WEIGHT_PATH;"/>
+	<Item Name="METoverPt_cut" Value="&APPLY_METoverPTcut;"/>
+	<Item Name="EtaPhi_cut" Value="&APPLY_EtaPhi_cut;"/>
+	<Item Name="Cut_dir"  Value="&Cut_PATH;"/>
+
+	<Item Name="Trigger_Central"    Value="&TRIGGER_CENTRAL;"/>
+	<Item Name="Trigger_FWD"        Value="&TRIGGER_FWD;"/>
+	
+	<Item Name="Trigger_SingleMuon"        Value="&TRIGGER_SINGLEMUON;"/>
+
+	<Item Name="Trigger_Single"        Value="&USE_SINGLE_TRIGGER;"/>	
+	<Item Name="Only_BtB"               Value="&ONLY_BACK_TO_BACK;"/>
+	<Item Name="Do_TOJM"          Value="&DO_TRG_OBJ_JET_MATCHING;"/>
+        <Item Name="AnalysisModule" Value="AnalysisModule_noPtBinning" />
+	
+        <Item Name="Debug" Value="false" />	
+
+        </UserConfig>
+    </Cycle>
+</JobConfiguration>

--- a/include/constants.h
+++ b/include/constants.h
@@ -222,18 +222,31 @@ constexpr static float s_Pt_Ave300HF_cut  = 426;
  // constexpr static float s_Pt_Ave450_cut  = 481;
  // constexpr static float s_Pt_Ave500_cut  = 528;
 
-//from 94X Run D 17Nov2017
+/* //from 94X Run D 17Nov2017 */
+/*  constexpr static float s_Pt_AveMC_cut   =40; */
+/*  constexpr static float s_Pt_Ave40_cut   =53 ; */
+/*  constexpr static float s_Pt_Ave60_cut   =74 ; */
+/*  constexpr static float s_Pt_Ave80_cut   =94 ; */
+/*  constexpr static float s_Pt_Ave140_cut  =158; */
+/*  constexpr static float s_Pt_Ave200_cut  =222; */
+/*  constexpr static float s_Pt_Ave260_cut  =284; */
+/*  constexpr static float s_Pt_Ave320_cut  =345; */
+/*  constexpr static float s_Pt_Ave400_cut  =443; */
+/*  constexpr static float s_Pt_Ave450_cut  =564; */
+/*  constexpr static float s_Pt_Ave500_cut  =598; */
+
+//from 94X max RunB to RunD
  constexpr static float s_Pt_AveMC_cut   =40;
- constexpr static float s_Pt_Ave40_cut   =53 ;
- constexpr static float s_Pt_Ave60_cut   =74 ;
- constexpr static float s_Pt_Ave80_cut   =94 ;
- constexpr static float s_Pt_Ave140_cut  =158;
- constexpr static float s_Pt_Ave200_cut  =222;
- constexpr static float s_Pt_Ave260_cut  =284;
- constexpr static float s_Pt_Ave320_cut  =345;
+ constexpr static float s_Pt_Ave40_cut   =40 ;
+ constexpr static float s_Pt_Ave60_cut   =72 ;
+ constexpr static float s_Pt_Ave80_cut   =95 ;
+ constexpr static float s_Pt_Ave140_cut  =160;
+ constexpr static float s_Pt_Ave200_cut  =226;
+ constexpr static float s_Pt_Ave260_cut  =283;
+ constexpr static float s_Pt_Ave320_cut  =344;
  constexpr static float s_Pt_Ave400_cut  =443;
- constexpr static float s_Pt_Ave450_cut  =564;
- constexpr static float s_Pt_Ave500_cut  =598;
+ constexpr static float s_Pt_Ave450_cut  =577;
+ constexpr static float s_Pt_Ave500_cut  =606;
          	 	 
 //from Di triggers 92X
  // constexpr static float d_Pt_AveMC_cut   =  51;

--- a/src/AnalysisModule_SiJetTrg.cxx
+++ b/src/AnalysisModule_SiJetTrg.cxx
@@ -211,8 +211,8 @@ class AnalysisModule_SiJetTrg: public uhh2::AnalysisModule {
 
     if(trigger_fwd) cout<<"!!!WARNING fwd for si trg not implemented yet\n"; //FIXME
     
-    ts  = (ctx.get("Trigger_Single") == "true"); //if true use single jet trigger, if false di jet trigger TODO collapse the SiJet and DiJEt AnalysisModules into one
-    // ts = true;
+    //ts  = (ctx.get("Trigger_Single") == "true"); //if true use single jet trigger, if false di jet trigger TODO collapse the SiJet and DiJEt AnalysisModules into one
+    ts = true;
     onlyBtB = (ctx.get("Only_BtB") == "true");
     if(debug) cout<<"onlyBtb is "<<onlyBtB<<endl;
         
@@ -668,6 +668,7 @@ class AnalysisModule_SiJetTrg: public uhh2::AnalysisModule {
 	else if(JEC_Version == "Summer16_03Feb2017_V4") jetER_smearer.reset(new GenericJetResolutionSmearer(ctx, "jets", "genjets",  JERSmearing::SF_13TeV_2016_03Feb2017));
 	else if(JEC_Version == "Summer16_03Feb2017_V5") jetER_smearer.reset(new GenericJetResolutionSmearer(ctx, "jets", "genjets",  JERSmearing::SF_13TeV_2016_03Feb2017));
 	else if(JEC_Version == "Summer16_03Feb2017_V6") jetER_smearer.reset(new GenericJetResolutionSmearer(ctx, "jets", "genjets",  JERSmearing::SF_13TeV_2016_03Feb2017));
+	else if(JEC_Version == "Fall17_17Nov2017_V4") jetER_smearer.reset(new GenericJetResolutionSmearer(ctx, "jets", "genjets",  JERSmearing::SF_13TeV_2016_03Feb2017));
 	else throw runtime_error("In AnalysisModule_SiJetTrg.cxx: When setting up JER smearer, invalid 'JEC_Version' was specified.");
       }
      
@@ -1162,19 +1163,22 @@ class AnalysisModule_SiJetTrg: public uhh2::AnalysisModule {
         pass_minBias = (minBias_sel->passes(event));
 
       if(ts){
-	pass_trigger40 = (pass_trigger40 && pt_ave>trg_thresh[0]   && pt_ave<trg_thresh[1]);
-	pass_trigger60 = (pass_trigger60 && pt_ave>trg_thresh[1]   && pt_ave<trg_thresh[2]);
-	pass_trigger80 = (pass_trigger80 && pt_ave>trg_thresh[2]   && pt_ave<trg_thresh[3]); 
-	pass_trigger140 = (pass_trigger140 && pt_ave>trg_thresh[3] && pt_ave<trg_thresh[4]);
-	pass_trigger200 = (pass_trigger200 && pt_ave>trg_thresh[4] && pt_ave<trg_thresh[5]);
-	pass_trigger260 = (pass_trigger260 && pt_ave>trg_thresh[5] && pt_ave<trg_thresh[6]); 
-	pass_trigger320 = (pass_trigger320 && pt_ave>trg_thresh[6] && pt_ave<trg_thresh[7]); 
-	pass_trigger400 = (pass_trigger400 && pt_ave>trg_thresh[7] && pt_ave<trg_thresh[8]);
-	pass_trigger450 = (pass_trigger450 && pt_ave>trg_thresh[8] && pt_ave<trg_thresh[9]);
-	pass_trigger500 = (pass_trigger500 && pt_ave>trg_thresh[9]);
+	//ToDo: use eta_cut for separation between central and forward triggers
+
+	pass_trigger40 = (trigger40_sel->passes(event) && pt_ave>trg_thresh[0]   && pt_ave<trg_thresh[1]);
+	pass_trigger60 = (trigger60_sel->passes(event) && pt_ave>trg_thresh[1]   && pt_ave<trg_thresh[2]);
+	pass_trigger80 = (trigger80_sel->passes(event) && pt_ave>trg_thresh[2]   && pt_ave<trg_thresh[3]); 
+	pass_trigger140 = (trigger140_sel->passes(event) && pt_ave>trg_thresh[3] && pt_ave<trg_thresh[4]);
+	pass_trigger200 = (trigger200_sel->passes(event) && pt_ave>trg_thresh[4] && pt_ave<trg_thresh[5]);
+	pass_trigger260 = (trigger260_sel->passes(event) && pt_ave>trg_thresh[5] && pt_ave<trg_thresh[6]); 
+	pass_trigger320 = (trigger320_sel->passes(event) && pt_ave>trg_thresh[6] && pt_ave<trg_thresh[7]); 
+	pass_trigger400 = (trigger400_sel->passes(event) && pt_ave>trg_thresh[7] && pt_ave<trg_thresh[8]);
+	pass_trigger450 = (trigger450_sel->passes(event) && pt_ave>trg_thresh[8] && pt_ave<trg_thresh[9]);
+	pass_trigger500 = (trigger500_sel->passes(event) && pt_ave>trg_thresh[9]);
       }
 
-      pass_trigger = pass_minBias || pass_trigger40 || pass_trigger60 || pass_trigger80 || pass_trigger140 || pass_trigger200  || pass_trigger260 || pass_trigger320 || pass_trigger400 || pass_trigger450 || pass_trigger500;
+      // pass_trigger = pass_minBias || pass_trigger40 || pass_trigger60 || pass_trigger80 || pass_trigger140 || pass_trigger200  || pass_trigger260 || pass_trigger320 || pass_trigger400 || pass_trigger450 || pass_trigger500;
+      pass_trigger = pass_trigger40 || pass_trigger60 || pass_trigger80 || pass_trigger140 || pass_trigger200  || pass_trigger260 || pass_trigger320 || pass_trigger400 || pass_trigger450 || pass_trigger500;
     
       if(debug){
 	cout << "before triggers: " << endl;

--- a/src/AnalysisModule_noPtBinning.cxx
+++ b/src/AnalysisModule_noPtBinning.cxx
@@ -1491,29 +1491,30 @@ else trigger300_HFJEC_sel.reset(new uhh2::AndSelection(ctx));
       pass_triggerSiMu = (triggerSiMu_sel->passes(event));
 
       pass_minBias = (minBias_sel->passes(event));
-
+      //      const double eta_cut = 2.853;
+      const double eta_cut = 6.0;//TEST without eta cut
       if(ts){
-	pass_trigger40 = (trigger40_sel->passes(event)  && (abs(probejet_eta) < 2.65) );
-	pass_trigger60 = (trigger60_sel->passes(event)  && (abs(probejet_eta) < 2.65)  );
-	pass_trigger80 = (trigger80_sel->passes(event)   && (abs(probejet_eta) < 2.65) );
-	pass_trigger140 = (trigger140_sel->passes(event) && (abs(probejet_eta) < 2.65) ); 
-	pass_trigger200 = (trigger200_sel->passes(event) && (abs(probejet_eta) < 2.65) ); 
-	pass_trigger260 = (trigger260_sel->passes(event) && (abs(probejet_eta) < 2.65) ); 
-	pass_trigger320 = (trigger320_sel->passes(event) && (abs(probejet_eta) < 2.65) ); 
-	pass_trigger400 = (trigger400_sel->passes(event) && (abs(probejet_eta) < 2.65) ); 
-	pass_trigger450 = (trigger450_sel->passes(event) && (abs(probejet_eta) < 2.65) );
-	pass_trigger500 = (trigger500_sel->passes(event) && (abs(probejet_eta) < 2.65) );
+	pass_trigger40 = (trigger40_sel->passes(event)  && (abs(probejet_eta) < eta_cut) );
+	pass_trigger60 = (trigger60_sel->passes(event)  && (abs(probejet_eta) < eta_cut)  );
+	pass_trigger80 = (trigger80_sel->passes(event)   && (abs(probejet_eta) < eta_cut) );
+	pass_trigger140 = (trigger140_sel->passes(event) && (abs(probejet_eta) < eta_cut) ); 
+	pass_trigger200 = (trigger200_sel->passes(event) && (abs(probejet_eta) < eta_cut) ); 
+	pass_trigger260 = (trigger260_sel->passes(event) && (abs(probejet_eta) < eta_cut) ); 
+	pass_trigger320 = (trigger320_sel->passes(event) && (abs(probejet_eta) < eta_cut) ); 
+	pass_trigger400 = (trigger400_sel->passes(event) && (abs(probejet_eta) < eta_cut) ); 
+	pass_trigger450 = (trigger450_sel->passes(event) && (abs(probejet_eta) < eta_cut) );
+	pass_trigger500 = (trigger500_sel->passes(event) && (abs(probejet_eta) < eta_cut) );
 
 	if(trigger_fwd){
-	  pass_trigger60_fwd = (trigger60_fwd_sel->passes(event)  && (abs(probejet_eta) > 2.65) );
-	  pass_trigger80_fwd = (trigger80_fwd_sel->passes(event)  && (abs(probejet_eta) > 2.65) );
-	  pass_trigger140_fwd = (trigger140_fwd_sel->passes(event)&& (abs(probejet_eta) > 2.65) );
-	  pass_trigger200_fwd = (trigger200_fwd_sel->passes(event)&& (abs(probejet_eta) > 2.65) );
-	  pass_trigger260_fwd = (trigger260_fwd_sel->passes(event)&& (abs(probejet_eta) > 2.65) );
-	  pass_trigger320_fwd = (trigger320_fwd_sel->passes(event)&& (abs(probejet_eta) > 2.65) );
-	  pass_trigger400_fwd = (trigger400_fwd_sel->passes(event)&& (abs(probejet_eta) > 2.65) );
-	  pass_trigger450_fwd = (trigger450_fwd_sel->passes(event)&& (abs(probejet_eta) > 2.65) );
-	  pass_trigger500_fwd = (trigger500_fwd_sel->passes(event)&& (abs(probejet_eta) > 2.65) );
+	  pass_trigger60_fwd = (trigger60_fwd_sel->passes(event)  && (abs(probejet_eta) > eta_cut) );
+	  pass_trigger80_fwd = (trigger80_fwd_sel->passes(event)  && (abs(probejet_eta) > eta_cut) );
+	  pass_trigger140_fwd = (trigger140_fwd_sel->passes(event)&& (abs(probejet_eta) > eta_cut) );
+	  pass_trigger200_fwd = (trigger200_fwd_sel->passes(event)&& (abs(probejet_eta) > eta_cut) );
+	  pass_trigger260_fwd = (trigger260_fwd_sel->passes(event)&& (abs(probejet_eta) > eta_cut) );
+	  pass_trigger320_fwd = (trigger320_fwd_sel->passes(event)&& (abs(probejet_eta) > eta_cut) );
+	  pass_trigger400_fwd = (trigger400_fwd_sel->passes(event)&& (abs(probejet_eta) > eta_cut) );
+	  pass_trigger450_fwd = (trigger450_fwd_sel->passes(event)&& (abs(probejet_eta) > eta_cut) );
+	  pass_trigger500_fwd = (trigger500_fwd_sel->passes(event)&& (abs(probejet_eta) > eta_cut) );
 	}
 	
       }
@@ -1521,21 +1522,21 @@ else trigger300_HFJEC_sel.reset(new uhh2::AndSelection(ctx));
 	if(trigger_central){
 	  pass_triggerDi40 = (triggerDi40_sel->passes(event)  );
 	  pass_triggerDi60 = (triggerDi60_sel->passes(event) ) ;
-	  pass_triggerDi80 = (triggerDi80_sel->passes(event)   && (abs(probejet_eta) < 2.65));
-	  pass_triggerDi140 = (triggerDi140_sel->passes(event) && (abs(probejet_eta) < 2.65)); 
-	  pass_triggerDi200 = (triggerDi200_sel->passes(event) && (abs(probejet_eta) < 2.65)); 
-	  pass_triggerDi260 = (triggerDi260_sel->passes(event) && (abs(probejet_eta) < 2.65)); 
-	  pass_triggerDi320 = (triggerDi320_sel->passes(event) && (abs(probejet_eta) < 2.65)); 
-	  pass_triggerDi400 = (triggerDi400_sel->passes(event) && (abs(probejet_eta) < 2.65)); 
-	  pass_triggerDi500 = (triggerDi500_sel->passes(event) && (abs(probejet_eta) < 2.65));
+	  pass_triggerDi80 = (triggerDi80_sel->passes(event)   && (abs(probejet_eta) < eta_cut));
+	  pass_triggerDi140 = (triggerDi140_sel->passes(event) && (abs(probejet_eta) < eta_cut)); 
+	  pass_triggerDi200 = (triggerDi200_sel->passes(event) && (abs(probejet_eta) < eta_cut)); 
+	  pass_triggerDi260 = (triggerDi260_sel->passes(event) && (abs(probejet_eta) < eta_cut)); 
+	  pass_triggerDi320 = (triggerDi320_sel->passes(event) && (abs(probejet_eta) < eta_cut)); 
+	  pass_triggerDi400 = (triggerDi400_sel->passes(event) && (abs(probejet_eta) < eta_cut)); 
+	  pass_triggerDi500 = (triggerDi500_sel->passes(event) && (abs(probejet_eta) < eta_cut));
 	}
 	if(trigger_fwd){
-	  pass_trigger60_HFJEC = (trigger60_HFJEC_sel->passes(event)  && (abs(probejet_eta) > 2.65));
-	  pass_trigger80_HFJEC = (trigger80_HFJEC_sel->passes(event)  && (abs(probejet_eta) > 2.65));
-	  pass_trigger100_HFJEC = (trigger100_HFJEC_sel->passes(event)&& (abs(probejet_eta) > 2.65));
-	  pass_trigger160_HFJEC = (trigger160_HFJEC_sel->passes(event)&& (abs(probejet_eta) > 2.65));
-	  pass_trigger220_HFJEC = (trigger220_HFJEC_sel->passes(event)&& (abs(probejet_eta) > 2.65));
-	  pass_trigger300_HFJEC = (trigger300_HFJEC_sel->passes(event)&& (abs(probejet_eta) > 2.65));
+	  pass_trigger60_HFJEC = (trigger60_HFJEC_sel->passes(event)  && (abs(probejet_eta) > eta_cut));
+	  pass_trigger80_HFJEC = (trigger80_HFJEC_sel->passes(event)  && (abs(probejet_eta) > eta_cut));
+	  pass_trigger100_HFJEC = (trigger100_HFJEC_sel->passes(event)&& (abs(probejet_eta) > eta_cut));
+	  pass_trigger160_HFJEC = (trigger160_HFJEC_sel->passes(event)&& (abs(probejet_eta) > eta_cut));
+	  pass_trigger220_HFJEC = (trigger220_HFJEC_sel->passes(event)&& (abs(probejet_eta) > eta_cut));
+	  pass_trigger300_HFJEC = (trigger300_HFJEC_sel->passes(event)&& (abs(probejet_eta) > eta_cut));
 	}
       }
 
@@ -1590,9 +1591,11 @@ else trigger300_HFJEC_sel.reset(new uhh2::AndSelection(ctx));
 	pass_trigger = pass_triggerSiMu;
       }
       else{
-	bool pass_sng_trg = pass_minBias || pass_trigger40 || pass_trigger60 || pass_trigger80 || pass_trigger140 || pass_trigger200  || pass_trigger260 || pass_trigger320 || pass_trigger400 || pass_trigger450 || pass_trigger500;
+	//	bool pass_sng_trg = pass_minBias || pass_trigger40 || pass_trigger60 || pass_trigger80 || pass_trigger140 || pass_trigger200  || pass_trigger260 || pass_trigger320 || pass_trigger400 || pass_trigger450 || pass_trigger500;
+	bool pass_sng_trg = pass_trigger40 || pass_trigger60 || pass_trigger80 || pass_trigger140 || pass_trigger200  || pass_trigger260 || pass_trigger320 || pass_trigger400 || pass_trigger450 || pass_trigger500;// what for pass_minBias?
 	bool pass_si_trg_fwd =  pass_trigger60_fwd || pass_trigger80_fwd || pass_trigger140_fwd || pass_trigger200_fwd || pass_trigger260_fwd || pass_trigger320_fwd || pass_trigger400_fwd || pass_trigger450_fwd || pass_trigger500_fwd;
-	bool pass_di_trg_center = pass_minBias || pass_triggerDi40 || pass_triggerDi60 || pass_triggerDi80 || pass_triggerDi140 || pass_triggerDi200  || pass_triggerDi260 || pass_triggerDi320 || pass_triggerDi400 ||  pass_triggerDi500;
+	//	bool pass_di_trg_center = pass_minBias || pass_triggerDi40 || pass_triggerDi60 || pass_triggerDi80 || pass_triggerDi140 || pass_triggerDi200  || pass_triggerDi260 || pass_triggerDi320 || pass_triggerDi400 ||  pass_triggerDi500;
+	bool pass_di_trg_center = pass_triggerDi40 || pass_triggerDi60 || pass_triggerDi80 || pass_triggerDi140 || pass_triggerDi200  || pass_triggerDi260 || pass_triggerDi320 || pass_triggerDi400 ||  pass_triggerDi500; // what for pass_minBias?
 	bool pass_di_trg_HF =  pass_trigger60_HFJEC || pass_trigger80_HFJEC || pass_trigger100_HFJEC || pass_trigger160_HFJEC || pass_trigger220_HFJEC || pass_trigger300_HFJEC;
 
 	if(ts){
@@ -1788,19 +1791,23 @@ else trigger300_HFJEC_sel.reset(new uhh2::AndSelection(ctx));
    event.set(tt_jet2_pt_onoff_Resp,jet2_pt_onoff_Resp); 
    
    if(onlyBtB){
-     //turn jet2 around and check dR to jet1
-     float eta1 = jet1->eta();
-     float eta2 = -1.*jet2->eta();
-     float phi1 = jet1->phi();
-     float phi2 = TVector2::Phi_mpi_pi(jet2->phi()+3.14159265358979f);
-     
-     float deta = eta1 - eta2;
-     float dphi =  TVector2::Phi_mpi_pi(phi1 - phi2);
-     float dR = TMath::Sqrt( deta*deta + dphi*dphi );
+ // delta phi > 2.7
+     double deltaPhi = std::abs(TVector2::Phi_mpi_pi(jet1->phi() - jet2->phi()));
+     if (deltaPhi < 2.7) return false;
 
-     if(debug) cout<<"in BtB if with dR "<<dR<<endl;
+     // //turn jet2 around and check dR to jet1
+     // float eta1 = jet1->eta();
+     // float eta2 = -1.*jet2->eta();
+     // float phi1 = jet1->phi();
+     // float phi2 = TVector2::Phi_mpi_pi(jet2->phi()+3.14159265358979f);
      
-     if(dR>0.4) return false;
+     // float deta = eta1 - eta2;
+     // float dphi =  TVector2::Phi_mpi_pi(phi1 - phi2);
+     // float dR = TMath::Sqrt( deta*deta + dphi*dphi );
+
+     // if(debug) cout<<"in BtB if with dR "<<dR<<endl;
+     
+     // if(dR>0.4) return false;
    }
    
 
@@ -2041,7 +2048,7 @@ else trigger300_HFJEC_sel.reset(new uhh2::AndSelection(ctx));
     
     for(int i = 0; i<10; i++){
       if(passes_Si[i]){
-	cout<<"si central match jet id loop\n";
+	if(debug) cout<<"si central match jet id loop\n";
 	matchJetId_0_last = matchJetId_0;
 	matchJetId_1_last = matchJetId_1;
 	if(!ts){


### PR DESCRIPTION
-Back to Back requirement changed to (dPhi)<2.7
-pass_minBias removed from pass_trigger
-for extrapolation of trigger threshold read function, not TGraph
-"65" corresponds to SingleJet40, not needed

-pass_minBias removed from pass_trigger (AnalysisModule_SiJetTrg, AnalysisModule_noPtBinning)
-EtaPhi_cut should NOT be used for 2017 data
-pass_trigger140, etc should be set with trigger140_sel